### PR TITLE
Feat/round-1

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -1,22 +1,21 @@
 package com.loopers.application.user;
 
-import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.UserService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
 public class UserFacade {
     private final UserService userService;
 
-    public UserInfo signUp(String userId, String email, String birthDate, Gender gender) {
-        User user = userService.signUp(userId, email, birthDate, gender);
+    public UserInfo signUp(UserCommand.Create command) {
+        User user = userService.signUp(command);
         return UserInfo.from(user);
     }
 
@@ -26,8 +25,15 @@ public class UserFacade {
         return UserInfo.from(user);
     }
 
-    public UserInfo chargePoint(String userId, int amount) {
+    public UserPointInfo getMyPoint(String userId) {
+        return userService.findByUserId(userId)
+                .map(user -> UserPointInfo.from(user))
+                .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND));
+    }
+
+    public UserPointInfo chargePoint(String userId, int amount) {
         User user = userService.chargePoint(userId, amount);
-        return UserInfo.from(user);
+
+        return UserPointInfo.from(user);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -1,0 +1,30 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UserFacade {
+    private final UserService userService;
+
+    public UserInfo register(String userId, String email, String birthDate, Gender gender) {
+        User user = userService.register(userId, email, birthDate, gender);
+        return UserInfo.from(user);
+    }
+
+    public Optional<UserInfo> findByUserId(String userId) {
+        Optional<User> user = userService.findByUserId(userId);
+        return user.map(UserInfo::from);
+    }
+
+    public UserInfo chargePoint(String userId, int amount) {
+        User user = userService.chargePoint(userId, amount);
+        return UserInfo.from(user);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -3,6 +3,8 @@ package com.loopers.application.user;
 import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,14 +15,15 @@ import java.util.Optional;
 public class UserFacade {
     private final UserService userService;
 
-    public UserInfo register(String userId, String email, String birthDate, Gender gender) {
-        User user = userService.register(userId, email, birthDate, gender);
+    public UserInfo signUp(String userId, String email, String birthDate, Gender gender) {
+        User user = userService.signUp(userId, email, birthDate, gender);
         return UserInfo.from(user);
     }
 
-    public Optional<UserInfo> findByUserId(String userId) {
-        Optional<User> user = userService.findByUserId(userId);
-        return user.map(UserInfo::from);
+    public UserInfo getMyInfo(String userId) {
+        User user = userService.findByUserId(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND, userId));
+        return UserInfo.from(user);
     }
 
     public UserInfo chargePoint(String userId, int amount) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserInfo.java
@@ -1,0 +1,24 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+
+import java.time.LocalDate;
+
+public record UserInfo(
+        String userId,
+        String email,
+        LocalDate birthDate,
+        Gender gender,
+        Integer point
+) {
+    public static UserInfo from(User user) {
+        return new UserInfo(
+                user.getUserId(),
+                user.getEmail(),
+                user.getBirthDate(),
+                user.getGender(),
+                user.getPoint()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserPointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserPointInfo.java
@@ -1,0 +1,11 @@
+package com.loopers.application.user;
+
+import com.loopers.domain.user.User;
+
+public record UserPointInfo(
+        int point
+) {
+    public static UserPointInfo from(User user) {
+        return new UserPointInfo(user.getPoint());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/Gender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/Gender.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.user;
+
+public enum Gender {
+    MALE,
+    FEMALE
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.user;
 
 import com.loopers.domain.BaseEntity;
-import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
@@ -28,10 +27,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Gender gender;
 
+    private Integer point;
+
     protected User() {
     }
 
-    public User(String userId, String email, String birthDateStr, Gender gender) {
+    public User(String userId, String email, String birthDateStr, Gender gender, Integer point) {
         validateUserId(userId);
         validateEmail(email);
         this.birthDate = validateAndParseBirthDate(birthDateStr);
@@ -40,6 +41,7 @@ public class User extends BaseEntity {
         this.userId = userId;
         this.email = email;
         this.gender = gender;
+        this.point = point;
     }
 
     private void validateUserId(String userId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -27,12 +27,13 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Gender gender;
 
-    private Integer point;
+    @Column(nullable = false)
+    private int point;
 
     protected User() {
     }
 
-    public User(String userId, String email, String birthDateStr, Gender gender, Integer point) {
+    public User(String userId, String email, String birthDateStr, Gender gender, int point) {
         validateUserId(userId);
         validateEmail(email);
         this.birthDate = validateAndParseBirthDate(birthDateStr);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -76,7 +76,7 @@ public class User extends BaseEntity {
             throw new CoreException(ErrorType.BAD_REQUEST, "email은 비어있을 수 없습니다.");
         }
 
-        if (!email.matches("^[^@]+@[^@]+\\.[^@]+$")) {
+        if (!email.matches("^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?@[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?\\.[a-zA-Z]{2,}$")) {
             throw new CoreException(ErrorType.INVALID_INPUT_FORMAT, "올바른 이메일 형식이 아닙니다. 올바른 이메일 형식은 xx@yy.zz와 같습니다.");
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,0 +1,82 @@
+package com.loopers.domain.user;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+@Entity
+@Table(name = "member")
+@Getter
+public class User extends BaseEntity {
+
+    @Column(unique = true, nullable = false)
+    private String userId;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    private LocalDate birthDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    protected User() {
+    }
+
+    public User(String userId, String email, String birthDateStr, Gender gender) {
+        validateUserId(userId);
+        validateEmail(email);
+        this.birthDate = validateAndParseBirthDate(birthDateStr);
+        validateGender(gender);
+
+        this.userId = userId;
+        this.email = email;
+        this.gender = gender;
+    }
+
+    private void validateUserId(String userId) {
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "userId는 비어있을 수 없습니다.");
+        }
+
+        if (!userId.matches("^[a-zA-Z0-9]{1,10}$")) {
+            throw new CoreException(ErrorType.INVALID_INPUT_FORMAT, "10자를 초과하는 userId는 생성할 수 없습니다.");
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "email은 비어있을 수 없습니다.");
+        }
+
+        if (!email.matches("^[^@]+@[^@]+\\.[^@]+$")) {
+            throw new CoreException(ErrorType.INVALID_INPUT_FORMAT, "올바른 이메일 형식이 아닙니다. 올바른 이메일 형식은 xx@yy.zz와 같습니다.");
+        }
+    }
+
+    private LocalDate validateAndParseBirthDate(String birthDateStr) {
+        if (birthDateStr == null || birthDateStr.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 비어있을 수 없습니다.");
+        }
+
+        try {
+            return LocalDate.parse(birthDateStr, DateTimeFormatter.ISO_LOCAL_DATE);
+        } catch (DateTimeParseException e) {
+            throw new CoreException(ErrorType.INVALID_INPUT_FORMAT, "생년월일은 yyyy-MM-dd 형식이어야 합니다.");
+        }
+    }
+    
+    private void validateGender(Gender gender) {
+        if (gender == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "성별은 필수값입니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -44,6 +44,18 @@ public class User extends BaseEntity {
         this.point = point;
     }
 
+    public void chargePoint(int amount) {
+        validateAmount(amount);
+
+        this.point += amount;
+    }
+
+    private void validateAmount(int amount) {
+        if (amount  <= 0) {
+            throw new CoreException(ErrorType.INVALID_INPUT_FORMAT, "0원 이하는 충전할 수 없습니다.");
+        }
+    }
+
     private void validateUserId(String userId) {
         if (userId == null || userId.isBlank()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "userId는 비어있을 수 없습니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -33,16 +33,20 @@ public class User extends BaseEntity {
     protected User() {
     }
 
-    public User(String userId, String email, String birthDateStr, Gender gender, int point) {
-        validateUserId(userId);
-        validateEmail(email);
-        this.birthDate = validateAndParseBirthDate(birthDateStr);
-        validateGender(gender);
-
+    private User(String userId, String email, LocalDate birthDate, Gender gender, int point) {
         this.userId = userId;
         this.email = email;
+        this.birthDate = birthDate;
         this.gender = gender;
         this.point = point;
+    }
+
+    public static User of(UserCommand.Create command) {
+        validateUserId(command.userId());
+        validateEmail(command.email());
+        validateGender(command.gender());
+
+        return new User(command.userId(), command.email(), validateAndParseBirthDate(command.birthDate()), command.gender(), 0);
     }
 
     public void chargePoint(int amount) {
@@ -51,13 +55,13 @@ public class User extends BaseEntity {
         this.point += amount;
     }
 
-    private void validateAmount(int amount) {
+    private static void validateAmount(int amount) {
         if (amount  <= 0) {
             throw new CoreException(ErrorType.INVALID_INPUT_FORMAT, "0원 이하는 충전할 수 없습니다.");
         }
     }
 
-    private void validateUserId(String userId) {
+    private static void validateUserId(String userId) {
         if (userId == null || userId.isBlank()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "userId는 비어있을 수 없습니다.");
         }
@@ -67,7 +71,7 @@ public class User extends BaseEntity {
         }
     }
 
-    private void validateEmail(String email) {
+    private static void validateEmail(String email) {
         if (email == null || email.isBlank()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "email은 비어있을 수 없습니다.");
         }
@@ -77,7 +81,7 @@ public class User extends BaseEntity {
         }
     }
 
-    private LocalDate validateAndParseBirthDate(String birthDateStr) {
+    private static LocalDate validateAndParseBirthDate(String birthDateStr) {
         if (birthDateStr == null || birthDateStr.isBlank()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "생년월일은 비어있을 수 없습니다.");
         }
@@ -89,7 +93,7 @@ public class User extends BaseEntity {
         }
     }
     
-    private void validateGender(Gender gender) {
+    private static void validateGender(Gender gender) {
         if (gender == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "성별은 필수값입니다.");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.user;
+
+public class UserCommand {
+
+    public record Create(
+            String userId,
+            String email,
+            String birthDate,
+            Gender gender
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,9 +1,13 @@
 package com.loopers.domain.user;
 
+import java.util.Optional;
+
 public interface UserRepository {
 
     User save(User user);
 
     boolean existsByUserId(String userId);
+
+    Optional<User> findByUserId(String userId);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.user;
+
+public interface UserRepository {
+
+    User save(User user);
+
+    boolean existsByUserId(String userId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -19,12 +19,12 @@ public class UserService {
     }
 
     @Transactional
-    public User signUp(String userId, String email, String birthDate, Gender gender) {
-        if (userRepository.existsByUserId(userId)) {
-            throw new CoreException(ErrorType.ALREADY_REGISTERED_USER, userId);
+    public User signUp(UserCommand.Create command) {
+        if (userRepository.existsByUserId(command.userId())) {
+            throw new CoreException(ErrorType.ALREADY_REGISTERED_USER, command.userId());
         }
         
-        User user = new User(userId, email, birthDate, gender, 0);
+        User user = User.of(command);
 
         return userRepository.save(user);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 public class UserService {
     
@@ -25,5 +27,10 @@ public class UserService {
         User user = new User(userId, email, birthDate, gender);
 
         return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<User> findByUserId(String userId) {
+        return userRepository.findByUserId(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -19,7 +19,7 @@ public class UserService {
     }
 
     @Transactional
-    public User register(String userId, String email, String birthDate, Gender gender) {
+    public User signUp(String userId, String email, String birthDate, Gender gender) {
         if (userRepository.existsByUserId(userId)) {
             throw new CoreException(ErrorType.ALREADY_REGISTERED_USER, userId);
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -24,7 +24,7 @@ public class UserService {
             throw new CoreException(ErrorType.ALREADY_REGISTERED_USER, userId);
         }
         
-        User user = new User(userId, email, birthDate, gender);
+        User user = new User(userId, email, birthDate, gender, 0);
 
         return userRepository.save(user);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+    
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public User register(String userId, String email, String birthDate, Gender gender) {
+        if (userRepository.existsByUserId(userId)) {
+            throw new CoreException(ErrorType.ALREADY_REGISTERED_USER, userId);
+        }
+        
+        User user = new User(userId, email, birthDate, gender);
+
+        return userRepository.save(user);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -33,4 +33,16 @@ public class UserService {
     public Optional<User> findByUserId(String userId) {
         return userRepository.findByUserId(userId);
     }
+
+    @Transactional
+    public User chargePoint(String userId, int amount) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.USER_NOT_FOUND, userId));
+
+        user.chargePoint(amount);
+        
+        userRepository.save(user);
+
+        return user;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUserId(String userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     boolean existsByUserId(String userId);
+
+    User findByUserId(String userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.loopers.domain.user.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @Component
 public class UserRepositoryImpl implements UserRepository {
 
@@ -23,5 +25,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public boolean existsByUserId(String userId) {
         return userJpaRepository.existsByUserId(userId);
+    }
+
+    @Override
+    public Optional<User> findByUserId(String userId) {
+        return Optional.ofNullable(userJpaRepository.findByUserId(userId));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.user;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Autowired
+    public UserRepositoryImpl(UserJpaRepository userJpaRepository) {
+        this.userJpaRepository = userJpaRepository;
+    }
+
+    @Override
+    public User save(User user) {
+        return userJpaRepository.save(user);
+    }
+
+    @Override
+    public boolean existsByUserId(String userId) {
+        return userJpaRepository.existsByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -8,6 +8,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -100,6 +101,13 @@ public class ApiControllerAdvice {
         } else {
             return failureResponse(ErrorType.BAD_REQUEST, null);
         }
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingRequestHeaderException e) {
+        String headerName  = e.getHeaderName();
+        String message = String.format("필수 헤더 '%s'가 누락되었습니다.", headerName);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 
     @ExceptionHandler

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ApiControllerAdvice.java
@@ -8,6 +8,8 @@ import com.loopers.support.error.ErrorType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -107,6 +109,17 @@ public class ApiControllerAdvice {
     public ResponseEntity<ApiResponse<?>> handleBadRequest(MissingRequestHeaderException e) {
         String headerName  = e.getHeaderName();
         String message = String.format("필수 헤더 '%s'가 누락되었습니다.", headerName);
+        return failureResponse(ErrorType.BAD_REQUEST, message);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<?>> handleBadRequest(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining(", "));
+
         return failureResponse(ErrorType.BAD_REQUEST, message);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,31 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Point V1 API", description = "포인트 조회, 충전")
+public interface PointV1ApiSpec {
+
+    @Operation(
+            summary = "내 포인트 조회",
+            description = "현재 인증된 사용자의 보유 포인트를 조회합니다."
+    )
+    ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(
+            @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
+            String userId
+    );
+
+    @Operation(
+            summary = "포인트 충전",
+            description = "유저의 포인트를 충전합니다."
+    )
+    ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
+            @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
+            String userId,
+            @Schema(name = "충전할 포인트", description = "충전할 포인트 단, 0이하의 값은 불허합니다.")
+            UserV1Dto.UserPointChargeRequest request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -13,7 +13,7 @@ public interface PointV1ApiSpec {
             summary = "내 포인트 조회",
             description = "현재 인증된 사용자의 보유 포인트를 조회합니다."
     )
-    ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(
+    ApiResponse<PointV1Dto.PointResponse> getMyPoint(
             @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
             String userId
     );
@@ -22,7 +22,7 @@ public interface PointV1ApiSpec {
             summary = "포인트 충전",
             description = "유저의 포인트를 충전합니다."
     )
-    ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
+    ApiResponse<PointV1Dto.PointResponse> chargePoints(
             @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
             String userId,
             @Schema(name = "충전할 포인트", description = "충전할 포인트 단, 0이하의 값은 불허합니다.")

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,20 +1,15 @@
 package com.loopers.interfaces.api.point;
 
 import com.loopers.application.user.UserFacade;
-import com.loopers.application.user.UserInfo;
+import com.loopers.application.user.UserPointInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.user.UserV1Dto;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
-
 @RestController
 @RequestMapping("/api/v1/points")
-public class PointV1Controller {
+public class PointV1Controller implements PointV1ApiSpec {
 
     private final UserFacade userFacade;
 
@@ -24,18 +19,19 @@ public class PointV1Controller {
     }
 
     @GetMapping("")
-    public ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(@RequestHeader("X-USER-ID") String userId) {
-        UserInfo userInfo = userFacade.getMyInfo(userId);
-        return ApiResponse.success(UserV1Dto.UserPointResponse.from(userInfo));
+    public ApiResponse<PointV1Dto.PointResponse> getMyPoint(@RequestHeader("X-USER-ID") String userId) {
+        UserPointInfo userPointInfo = userFacade.getMyPoint(userId);
+
+        return ApiResponse.success(PointV1Dto.PointResponse.from(userPointInfo));
     }
 
     @PostMapping("")
-    public ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
+    public ApiResponse<PointV1Dto.PointResponse> chargePoints(
             @RequestHeader("X-USER-ID") String userId,
-            @Valid @RequestBody UserV1Dto.UserPointChargeRequest request)
+            @RequestBody UserV1Dto.UserPointChargeRequest request)
     {
-        UserInfo updatedUser = userFacade.chargePoint(userId, request.amount());
+        UserPointInfo userPointInfo = userFacade.chargePoint(userId, request.amount());
 
-        return ApiResponse.success(UserV1Dto.UserPointResponse.from(updatedUser));
+        return ApiResponse.success(PointV1Dto.PointResponse.from(userPointInfo));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,45 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.user.UserFacade;
+import com.loopers.application.user.UserInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/v1/points")
+public class PointV1Controller {
+
+    private final UserFacade userFacade;
+
+    @Autowired
+    public PointV1Controller(UserFacade userFacade) {
+        this.userFacade = userFacade;
+    }
+
+    @GetMapping("")
+    public ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(@RequestHeader("X-USER-ID") String userId) {
+        Optional<UserInfo> foundUser = userFacade.findByUserId(userId);
+
+        if (foundUser.isEmpty()) {
+            throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
+        }
+
+        return ApiResponse.success(UserV1Dto.UserPointResponse.from(foundUser.get()));
+    }
+
+    @PostMapping("")
+    public ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
+            @RequestHeader("X-USER-ID") String userId,
+            @RequestBody UserV1Dto.UserPointChargeRequest request)
+    {
+        UserInfo updatedUser = userFacade.chargePoint(userId, request.amount());
+
+        return ApiResponse.success(UserV1Dto.UserPointResponse.from(updatedUser));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -25,13 +25,8 @@ public class PointV1Controller {
 
     @GetMapping("")
     public ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(@RequestHeader("X-USER-ID") String userId) {
-        Optional<UserInfo> foundUser = userFacade.findByUserId(userId);
-
-        if (foundUser.isEmpty()) {
-            throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
-        }
-
-        return ApiResponse.success(UserV1Dto.UserPointResponse.from(foundUser.get()));
+        UserInfo userInfo = userFacade.getMyInfo(userId);
+        return ApiResponse.success(UserV1Dto.UserPointResponse.from(userInfo));
     }
 
     @PostMapping("")

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -6,6 +6,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,7 +37,7 @@ public class PointV1Controller {
     @PostMapping("")
     public ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
             @RequestHeader("X-USER-ID") String userId,
-            @RequestBody UserV1Dto.UserPointChargeRequest request)
+            @Valid @RequestBody UserV1Dto.UserPointChargeRequest request)
     {
         UserInfo updatedUser = userFacade.chargePoint(userId, request.amount());
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,16 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.user.UserPointInfo;
+
+public class PointV1Dto {
+
+    public record PointResponse(
+            int point
+    ) {
+        public static PointResponse from(UserPointInfo userPointInfo) {
+            return new PointResponse(
+                    userPointInfo.point()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -16,4 +16,13 @@ public interface UserV1ApiSpec {
             @Schema(name = "회원가입 요청", description = "회원가입 할 사용자 정보")
             UserV1Dto.UserRegisterRequest request
     );
+
+    @Operation(
+            summary = "유저 조회",
+            description = "유저가 회원가입 시 입력한 아이디로 유저 정보를 조회해옵니다."
+    )
+    ApiResponse<UserV1Dto.UserResponse> getUser(
+            @Schema(name = "유저 조회", description = "회원가입시 유저가 등록한 아이디")
+            String userId
+    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -18,11 +18,20 @@ public interface UserV1ApiSpec {
     );
 
     @Operation(
-            summary = "유저 조회",
-            description = "유저가 회원가입 시 입력한 아이디로 유저 정보를 조회해옵니다."
+            summary = "내 정보 조회",
+            description = "현재 인증된 사용자의 정보를 조회합니다."
     )
     ApiResponse<UserV1Dto.UserResponse> getUser(
-            @Schema(name = "유저 조회", description = "회원가입시 유저가 등록한 아이디")
+            @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
+            String userId
+    );
+
+    @Operation(
+            summary = "내 포인트 조회",
+            description = "현재 인증된 사용자의 보유 포인트를 조회합니다."
+    )
+    ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(
+            @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
             String userId
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "User V1 API", description = "회원가입")
+public interface UserV1ApiSpec {
+
+    @Operation(
+            summary = "회원 가입",
+            description = "회원 가입을 진행합니다."
+    )
+    ApiResponse<UserV1Dto.UserResponse> register(
+            @Schema(name = "회원가입 요청", description = "회원가입 할 사용자 정보")
+            UserV1Dto.UserRegisterRequest request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -12,7 +12,7 @@ public interface UserV1ApiSpec {
             summary = "회원 가입",
             description = "회원 가입을 진행합니다."
     )
-    ApiResponse<UserV1Dto.UserResponse> register(
+    ApiResponse<UserV1Dto.UserResponse> signUp(
             @Schema(name = "회원가입 요청", description = "회원가입 할 사용자 정보")
             UserV1Dto.UserRegisterRequest request
     );
@@ -21,7 +21,7 @@ public interface UserV1ApiSpec {
             summary = "내 정보 조회",
             description = "현재 인증된 사용자의 정보를 조회합니다."
     )
-    ApiResponse<UserV1Dto.UserResponse> getUser(
+    ApiResponse<UserV1Dto.UserResponse> getMyInfo(
             @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
             String userId
     );

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -34,4 +34,15 @@ public interface UserV1ApiSpec {
             @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
             String userId
     );
+
+    @Operation(
+            summary = "포인트 충전",
+            description = "유저의 포인트를 충전합니다."
+    )
+    ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
+            @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
+            String userId,
+            @Schema(name = "충전할 포인트", description = "충전할 포인트 단, 0이하의 값은 불허합니다.")
+            UserV1Dto.UserPointChargeRequest request
+    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -14,7 +14,7 @@ public interface UserV1ApiSpec {
     )
     ApiResponse<UserV1Dto.UserResponse> signUp(
             @Schema(name = "회원가입 요청", description = "회원가입 할 사용자 정보")
-            UserV1Dto.UserRegisterRequest request
+            UserV1Dto.UserSignUpRequest request
     );
 
     @Operation(

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "User V1 API", description = "회원가입")
+@Tag(name = "User V1 API", description = "회원가입, 내 정보 조회")
 public interface UserV1ApiSpec {
 
     @Operation(
@@ -24,25 +24,5 @@ public interface UserV1ApiSpec {
     ApiResponse<UserV1Dto.UserResponse> getUser(
             @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
             String userId
-    );
-
-    @Operation(
-            summary = "내 포인트 조회",
-            description = "현재 인증된 사용자의 보유 포인트를 조회합니다."
-    )
-    ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(
-            @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
-            String userId
-    );
-
-    @Operation(
-            summary = "포인트 충전",
-            description = "유저의 포인트를 충전합니다."
-    )
-    ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
-            @Schema(name = "사용자 ID", description = "X-USER-ID 헤더로 전달되는 현재 사용자 식별자")
-            String userId,
-            @Schema(name = "충전할 포인트", description = "충전할 포인트 단, 0이하의 값은 불허합니다.")
-            UserV1Dto.UserPointChargeRequest request
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -28,8 +28,8 @@ public class UserV1Controller implements UserV1ApiSpec {
         return ApiResponse.success(UserV1Dto.UserResponse.from(registerUser));
     }
 
-    @GetMapping("/{userId}")
-    public ApiResponse<UserV1Dto.UserResponse> getUser(@PathVariable("userId") String userId) {
+    @GetMapping("")
+    public ApiResponse<UserV1Dto.UserResponse> getUser(@RequestHeader("X-USER-ID") String userId) {
         Optional<User> foundUser = userService.findByUserId(userId);
 
         if (foundUser.isEmpty()) {
@@ -37,5 +37,16 @@ public class UserV1Controller implements UserV1ApiSpec {
         }
 
         return ApiResponse.success(UserV1Dto.UserResponse.from(foundUser.get()));
+    }
+
+    @GetMapping("/points")
+    public ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(@RequestHeader("X-USER-ID") String userId) {
+        Optional<User> foundUser = userService.findByUserId(userId);
+
+        if (foundUser.isEmpty()) {
+            throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
+        }
+
+        return ApiResponse.success(UserV1Dto.UserPointResponse.from(foundUser.get()));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -3,12 +3,12 @@ package com.loopers.interfaces.api.user;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
 import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -26,5 +26,16 @@ public class UserV1Controller implements UserV1ApiSpec {
         User registerUser = userService.register(request.userId(), request.email(), request.birthDate(), request.gender());
 
         return ApiResponse.success(UserV1Dto.UserResponse.from(registerUser));
+    }
+
+    @GetMapping("/{userId}")
+    public ApiResponse<UserV1Dto.UserResponse> getUser(@PathVariable("userId") String userId) {
+        Optional<User> foundUser = userService.findByUserId(userId);
+
+        if (foundUser.isEmpty()) {
+            throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
+        }
+
+        return ApiResponse.success(UserV1Dto.UserResponse.from(foundUser.get()));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -3,12 +3,8 @@ package com.loopers.interfaces.api.user;
 import com.loopers.application.user.UserFacade;
 import com.loopers.application.user.UserInfo;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -22,20 +18,16 @@ public class UserV1Controller implements UserV1ApiSpec {
     }
 
     @PostMapping("")
-    public ApiResponse<UserV1Dto.UserResponse> register(@RequestBody UserV1Dto.UserRegisterRequest request) {
-        UserInfo userInfo = userFacade.register(request.userId(), request.email(), request.birthDate(), request.gender());
+    public ApiResponse<UserV1Dto.UserResponse> signUp(@RequestBody UserV1Dto.UserRegisterRequest request) {
+        UserInfo userInfo = userFacade.signUp(request.userId(), request.email(), request.birthDate(), request.gender());
 
         return ApiResponse.success(UserV1Dto.UserResponse.from(userInfo));
     }
 
-    @GetMapping("")
-    public ApiResponse<UserV1Dto.UserResponse> getUser(@RequestHeader("X-USER-ID") String userId) {
-        Optional<UserInfo> foundUser = userFacade.findByUserId(userId);
+    @GetMapping("/me")
+    public ApiResponse<UserV1Dto.UserResponse> getMyInfo(@RequestHeader("X-USER-ID") String userId) {
+        UserInfo userInfo = userFacade.getMyInfo(userId);
 
-        if (foundUser.isEmpty()) {
-            throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
-        }
-
-        return ApiResponse.success(UserV1Dto.UserResponse.from(foundUser.get()));
+        return ApiResponse.success(UserV1Dto.UserResponse.from(userInfo));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -2,6 +2,7 @@ package com.loopers.interfaces.api.user;
 
 import com.loopers.application.user.UserFacade;
 import com.loopers.application.user.UserInfo;
+import com.loopers.domain.user.UserCommand;
 import com.loopers.interfaces.api.ApiResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -18,8 +19,10 @@ public class UserV1Controller implements UserV1ApiSpec {
     }
 
     @PostMapping("")
-    public ApiResponse<UserV1Dto.UserResponse> signUp(@RequestBody UserV1Dto.UserRegisterRequest request) {
-        UserInfo userInfo = userFacade.signUp(request.userId(), request.email(), request.birthDate(), request.gender());
+    public ApiResponse<UserV1Dto.UserResponse> signUp(@RequestBody UserV1Dto.UserSignUpRequest request) {
+        UserCommand.Create command = request.toCommand();
+
+        UserInfo userInfo = userFacade.signUp(command);
 
         return ApiResponse.success(UserV1Dto.UserResponse.from(userInfo));
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserV1Controller implements UserV1ApiSpec {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserV1Controller(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("")
+    public ApiResponse<UserV1Dto.UserResponse> register(@RequestBody UserV1Dto.UserRegisterRequest request) {
+        User registerUser = userService.register(request.userId(), request.email(), request.birthDate(), request.gender());
+
+        return ApiResponse.success(UserV1Dto.UserResponse.from(registerUser));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.user;
 
-import com.loopers.domain.user.User;
-import com.loopers.domain.user.UserService;
+import com.loopers.application.user.UserFacade;
+import com.loopers.application.user.UserInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -14,23 +14,23 @@ import java.util.Optional;
 @RequestMapping("/api/v1/users")
 public class UserV1Controller implements UserV1ApiSpec {
 
-    private final UserService userService;
+    private final UserFacade userFacade;
 
     @Autowired
-    public UserV1Controller(UserService userService) {
-        this.userService = userService;
+    public UserV1Controller(UserFacade userFacade) {
+        this.userFacade = userFacade;
     }
 
     @PostMapping("")
     public ApiResponse<UserV1Dto.UserResponse> register(@RequestBody UserV1Dto.UserRegisterRequest request) {
-        User registerUser = userService.register(request.userId(), request.email(), request.birthDate(), request.gender());
+        UserInfo userInfo = userFacade.register(request.userId(), request.email(), request.birthDate(), request.gender());
 
-        return ApiResponse.success(UserV1Dto.UserResponse.from(registerUser));
+        return ApiResponse.success(UserV1Dto.UserResponse.from(userInfo));
     }
 
     @GetMapping("")
     public ApiResponse<UserV1Dto.UserResponse> getUser(@RequestHeader("X-USER-ID") String userId) {
-        Optional<User> foundUser = userService.findByUserId(userId);
+        Optional<UserInfo> foundUser = userFacade.findByUserId(userId);
 
         if (foundUser.isEmpty()) {
             throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
@@ -41,7 +41,7 @@ public class UserV1Controller implements UserV1ApiSpec {
 
     @GetMapping("/points")
     public ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(@RequestHeader("X-USER-ID") String userId) {
-        Optional<User> foundUser = userService.findByUserId(userId);
+        Optional<UserInfo> foundUser = userFacade.findByUserId(userId);
 
         if (foundUser.isEmpty()) {
             throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
@@ -55,7 +55,7 @@ public class UserV1Controller implements UserV1ApiSpec {
             @RequestHeader("X-USER-ID") String userId,
             @RequestBody UserV1Dto.UserPointChargeRequest request)
     {
-        User updatedUser = userService.chargePoint(userId, request.amount());
+        UserInfo updatedUser = userFacade.chargePoint(userId, request.amount());
 
         return ApiResponse.success(UserV1Dto.UserPointResponse.from(updatedUser));
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -38,25 +38,4 @@ public class UserV1Controller implements UserV1ApiSpec {
 
         return ApiResponse.success(UserV1Dto.UserResponse.from(foundUser.get()));
     }
-
-    @GetMapping("/points")
-    public ApiResponse<UserV1Dto.UserPointResponse> getUserPoints(@RequestHeader("X-USER-ID") String userId) {
-        Optional<UserInfo> foundUser = userFacade.findByUserId(userId);
-
-        if (foundUser.isEmpty()) {
-            throw new CoreException(ErrorType.USER_NOT_FOUND, userId);
-        }
-
-        return ApiResponse.success(UserV1Dto.UserPointResponse.from(foundUser.get()));
-    }
-
-    @PostMapping("/points")
-    public ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
-            @RequestHeader("X-USER-ID") String userId,
-            @RequestBody UserV1Dto.UserPointChargeRequest request)
-    {
-        UserInfo updatedUser = userFacade.chargePoint(userId, request.amount());
-
-        return ApiResponse.success(UserV1Dto.UserPointResponse.from(updatedUser));
-    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -49,4 +49,14 @@ public class UserV1Controller implements UserV1ApiSpec {
 
         return ApiResponse.success(UserV1Dto.UserPointResponse.from(foundUser.get()));
     }
+
+    @PostMapping("/points")
+    public ApiResponse<UserV1Dto.UserPointResponse> chargePoints(
+            @RequestHeader("X-USER-ID") String userId,
+            @RequestBody UserV1Dto.UserPointChargeRequest request)
+    {
+        User updatedUser = userService.chargePoint(userId, request.amount());
+
+        return ApiResponse.success(UserV1Dto.UserPointResponse.from(updatedUser));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -53,4 +53,8 @@ public class UserV1Dto {
             @NotNull
             Gender gender
     ) {}
+
+    public record UserPointChargeRequest (
+            int amount
+    ) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -25,6 +25,18 @@ public class UserV1Dto {
         }
     }
 
+    public record UserPointResponse(
+            String userId,
+            Integer point
+    ) {
+        public static UserPointResponse from(User user) {
+            return new UserPointResponse(
+                    user.getUserId(),
+                    user.getPoint()
+            );
+        }
+    }
+
     public record UserRegisterRequest(
             @NotBlank
             @NotNull

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -2,7 +2,7 @@ package com.loopers.interfaces.api.user;
 
 import com.loopers.application.user.UserInfo;
 import com.loopers.domain.user.Gender;
-import jakarta.validation.constraints.Min;
+import com.loopers.domain.user.UserCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -26,19 +26,7 @@ public class UserV1Dto {
         }
     }
 
-    public record UserPointResponse(
-            String userId,
-            Integer point
-    ) {
-        public static UserPointResponse from(UserInfo userInfo) {
-            return new UserPointResponse(
-                    userInfo.userId(),
-                    userInfo.point()
-            );
-        }
-    }
-
-    public record UserRegisterRequest(
+    public record UserSignUpRequest(
             @NotBlank
             @NotNull
             String userId,
@@ -53,10 +41,18 @@ public class UserV1Dto {
 
             @NotNull
             Gender gender
-    ) {}
+    ) {
+        public UserCommand.Create toCommand() {
+            return new UserCommand.Create(
+                    userId,
+                    email,
+                    birthDate,
+                    gender
+            );
+        }
+    }
 
     public record UserPointChargeRequest (
-            @Min(value = 1, message = "충전 금액은 1원 이상이어야 합니다.")
             int amount
     ) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,0 +1,44 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public class UserV1Dto {
+
+    public record UserResponse(
+            String userId,
+            String email,
+            LocalDate birthDate,
+            Gender gender
+    ) {
+        public static UserResponse from(User user) {
+            return new UserResponse(
+                    user.getUserId(),
+                    user.getEmail(),
+                    user.getBirthDate(),
+                    user.getGender()
+            );
+        }
+    }
+
+    public record UserRegisterRequest(
+            @NotBlank
+            @NotNull
+            String userId,
+
+            @NotBlank
+            @NotNull
+            String email,
+
+            @NotBlank
+            @NotNull
+            String birthDate,
+
+            @NotNull
+            Gender gender
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -2,6 +2,7 @@ package com.loopers.interfaces.api.user;
 
 import com.loopers.application.user.UserInfo;
 import com.loopers.domain.user.Gender;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -55,6 +56,7 @@ public class UserV1Dto {
     ) {}
 
     public record UserPointChargeRequest (
+            @Min(value = 1, message = "충전 금액은 1원 이상이어야 합니다.")
             int amount
     ) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Dto.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.user;
 
+import com.loopers.application.user.UserInfo;
 import com.loopers.domain.user.Gender;
-import com.loopers.domain.user.User;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -15,12 +15,12 @@ public class UserV1Dto {
             LocalDate birthDate,
             Gender gender
     ) {
-        public static UserResponse from(User user) {
+        public static UserResponse from(UserInfo userInfo) {
             return new UserResponse(
-                    user.getUserId(),
-                    user.getEmail(),
-                    user.getBirthDate(),
-                    user.getGender()
+                    userInfo.userId(),
+                    userInfo.email(),
+                    userInfo.birthDate(),
+                    userInfo.gender()
             );
         }
     }
@@ -29,10 +29,10 @@ public class UserV1Dto {
             String userId,
             Integer point
     ) {
-        public static UserPointResponse from(User user) {
+        public static UserPointResponse from(UserInfo userInfo) {
             return new UserPointResponse(
-                    user.getUserId(),
-                    user.getPoint()
+                    userInfo.userId(),
+                    userInfo.point()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -11,7 +11,11 @@ public enum ErrorType {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(), "일시적인 오류가 발생했습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
-    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다.");
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
+
+    /** User 관련 예외 **/
+    INVALID_INPUT_FORMAT(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "입력 형식이 올바르지 않습니다."),
+    ALREADY_REGISTERED_USER(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 회원가입이 되어 있습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -15,7 +15,8 @@ public enum ErrorType {
 
     /** User 관련 예외 **/
     INVALID_INPUT_FORMAT(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "입력 형식이 올바르지 않습니다."),
-    ALREADY_REGISTERED_USER(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 회원가입이 되어 있습니다.");
+    ALREADY_REGISTERED_USER(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 회원가입이 되어 있습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "회원이 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceIntegrationTest {
+    @Autowired
+    private UserService userService;
+
+    @MockitoSpyBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("회원 가입 시")
+    @Nested
+    class Register {
+        @Test
+        @DisplayName("User 저장이 수행된다.")
+        void saveUser_whenUserRegister() {
+            // arrange
+            String userId = "testUser";
+            String email = "test@gmail.com";
+            String birthDate = "1996-08-16";
+            Gender gender = Gender.MALE;
+
+            // act
+            User savedUser = userService.register(userId, email, birthDate, gender);
+
+            // assert
+            assertThat(savedUser.getUserId()).isEqualTo(userId);
+            assertThat(savedUser.getEmail()).isEqualTo(email);
+            verify(userRepository).save(any(User.class));
+            verify(userRepository).existsByUserId(userId);
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 회원이라면 ALREADY_REGISTERED_USER 예외를 발생한다.")
+        void throwAlreadyRegisteredUserException_whenProvidedDuplicateUserId() {
+            // arrange
+            String userId = "duplicate";
+            String email = "test@gmail.com";
+            String birthDate = "1996-08-16";
+            Gender gender = Gender.MALE;
+
+            userService.register(userId, email, birthDate, gender);
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                userService.register(userId, email, birthDate, gender);
+            });
+
+            // assert
+            assertEquals(ErrorType.ALREADY_REGISTERED_USER, exception.getErrorType());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -47,7 +47,7 @@ class UserServiceIntegrationTest {
             Gender gender = Gender.MALE;
 
             // act
-            User savedUser = userService.register(userId, email, birthDate, gender);
+            User savedUser = userService.signUp(userId, email, birthDate, gender);
 
             // assert
             assertThat(savedUser.getUserId()).isEqualTo(userId);
@@ -65,11 +65,11 @@ class UserServiceIntegrationTest {
             String birthDate = "1996-08-16";
             Gender gender = Gender.MALE;
 
-            userService.register(userId, email, birthDate, gender);
+            userService.signUp(userId, email, birthDate, gender);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                userService.register(userId, email, birthDate, gender);
+                userService.signUp(userId, email, birthDate, gender);
             });
 
             // assert
@@ -85,7 +85,7 @@ class UserServiceIntegrationTest {
         void returnUserInfo_whenUserExists() {
             // arrange
             String userId = "testUser";
-            User savedUser = userService.register(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            User savedUser = userService.signUp(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
 
             // act
             Optional<User> foundUser = userService.findByUserId(userId);
@@ -123,7 +123,7 @@ class UserServiceIntegrationTest {
         void returnUsersPoints_whenUserExists() {
             // arrange
             String userId = "testUser";
-            User savedUser = userService.register(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            User savedUser = userService.signUp(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
 
             // act
             Optional<User> foundUser = userService.findByUserId(userId);
@@ -176,7 +176,7 @@ class UserServiceIntegrationTest {
         void returnUpdatedUser_whenChargePointToExistingUser() {
             // arrange
             String userId = "testUser";
-            User savedUser = userService.register(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            User savedUser = userService.signUp(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
 
             clearInvocations(userRepository);
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -114,4 +114,42 @@ class UserServiceIntegrationTest {
             verify(userRepository).findByUserId(nonExistUserId);
         }
     }
+
+    @DisplayName("사용자의 포인트를 조회할 때")
+    @Nested
+    class GetUserPoint {
+        @DisplayName("해당 ID의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnUsersPoints_whenUserExists() {
+            // arrange
+            String userId = "testUser";
+            User savedUser = userService.register(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+
+            // act
+            Optional<User> foundUser = userService.findByUserId(userId);
+
+            // assert
+            assertThat(foundUser)
+                    .isPresent()
+                    .hasValueSatisfying(user -> {
+                        assertThat(user.getUserId()).isEqualTo(savedUser.getUserId());
+                        assertThat(user.getPoint()).isEqualTo(0);
+                    });
+            verify(userRepository).findByUserId(userId);
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnEmpty_whenUserDoesNotExist() {
+            // arrange
+            String nonExistUserId = "nonExistUserId";
+
+            // act
+            Optional<User>  foundUser = userService.findByUserId(nonExistUserId);
+
+            // assert
+            assertThat(foundUser).isEmpty();
+            verify(userRepository).findByUserId(nonExistUserId);
+        }
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.*;
@@ -72,6 +74,44 @@ class UserServiceIntegrationTest {
 
             // assert
             assertEquals(ErrorType.ALREADY_REGISTERED_USER, exception.getErrorType());
+        }
+    }
+
+    @DisplayName("회원이 내 정보를 조회할 때")
+    @Nested
+    class GetUser {
+        @DisplayName("해당 ID의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        @Test
+        void returnUserInfo_whenUserExists() {
+            // arrange
+            String userId = "testUser";
+            User savedUser = userService.register(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+
+            // act
+            Optional<User> foundUser = userService.findByUserId(userId);
+
+            // assert
+            assertThat(foundUser)
+                    .isPresent()
+                    .hasValueSatisfying(user -> {
+                        assertThat(user.getUserId()).isEqualTo(savedUser.getUserId());
+                        assertThat(user.getEmail()).isEqualTo(savedUser.getEmail());
+                    });
+            verify(userRepository).findByUserId(userId);
+        }
+
+        @DisplayName("해당 ID의 회원이 존재하지 않을 경우, null이 반환된다.")
+        @Test
+        void returnEmpty_whenUserDoesNotExist() {
+            // arrange
+            String nonExistUserId = "nonExistUserId";
+
+            // act
+            Optional<User> foundUser = userService.findByUserId(nonExistUserId);
+
+            // assert
+            assertThat(foundUser).isEmpty();
+            verify(userRepository).findByUserId(nonExistUserId);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -46,8 +46,10 @@ class UserServiceIntegrationTest {
             String birthDate = "1996-08-16";
             Gender gender = Gender.MALE;
 
+            UserCommand.Create command = new UserCommand.Create(userId, email, birthDate, gender);
+
             // act
-            User savedUser = userService.signUp(userId, email, birthDate, gender);
+            User savedUser = userService.signUp(command);
 
             // assert
             assertThat(savedUser.getUserId()).isEqualTo(userId);
@@ -65,11 +67,13 @@ class UserServiceIntegrationTest {
             String birthDate = "1996-08-16";
             Gender gender = Gender.MALE;
 
-            userService.signUp(userId, email, birthDate, gender);
+            UserCommand.Create command = new UserCommand.Create(userId, email, birthDate, gender);
+
+            userService.signUp(command);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                userService.signUp(userId, email, birthDate, gender);
+                userService.signUp(command);
             });
 
             // assert
@@ -85,7 +89,8 @@ class UserServiceIntegrationTest {
         void returnUserInfo_whenUserExists() {
             // arrange
             String userId = "testUser";
-            User savedUser = userService.signUp(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            UserCommand.Create command = new UserCommand.Create(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            User savedUser = userService.signUp(command);
 
             // act
             Optional<User> foundUser = userService.findByUserId(userId);
@@ -123,7 +128,8 @@ class UserServiceIntegrationTest {
         void returnUsersPoints_whenUserExists() {
             // arrange
             String userId = "testUser";
-            User savedUser = userService.signUp(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            UserCommand.Create command = new UserCommand.Create(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            User savedUser = userService.signUp(command);
 
             // act
             Optional<User> foundUser = userService.findByUserId(userId);
@@ -176,7 +182,9 @@ class UserServiceIntegrationTest {
         void returnUpdatedUser_whenChargePointToExistingUser() {
             // arrange
             String userId = "testUser";
-            User savedUser = userService.signUp(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+            UserCommand.Create command = new UserCommand.Create(userId, "test@gmail.com", "1996-08-16", Gender.MALE);
+
+            User savedUser = userService.signUp(command);
 
             clearInvocations(userRepository);
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -24,9 +24,10 @@ class UserTest {
             String email = "goodEmail@gmail.com";
             String birthDateStr = "1996-08-16";
             Gender gender = Gender.MALE;
+            UserCommand.Create command = new UserCommand.Create(userId, email, birthDateStr, gender);
 
             // act
-            User user = new User(userId, email, birthDateStr, gender, 0);
+            User user = User.of(command);
 
             // assert
             assertAll(
@@ -42,11 +43,11 @@ class UserTest {
         @Test
         void throwBadRequestException_whenUserIdIsNull() {
             // arrange
-            String nullId = null;
+            UserCommand.Create command = new UserCommand.Create(null, "email@gmail.com", "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(nullId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -57,11 +58,11 @@ class UserTest {
         @Test
         void throwBadRequestException_whenUserIdIsEmpty() {
             // arrange
-            String blankId = "";
+            UserCommand.Create command = new UserCommand.Create("", "email@gmail.com", "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(blankId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -72,11 +73,11 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenUserIdIsTooLong() {
             // arrange
-            String tooLongUserId = "tooLongUserId";
+            UserCommand.Create command = new UserCommand.Create("toooooLongUserId", "email@gmail.com", "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(tooLongUserId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -87,11 +88,11 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenUserIdContainsInvalidChars() {
             // arrange
-            String invalidUserId = "ㅎuserId";
+            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "email@gmail.com", "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(invalidUserId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -102,11 +103,11 @@ class UserTest {
         @Test
         void throwBadRequestException_whenEmailIsNull() {
             // arrange
-            String nullEmail = null;
+            UserCommand.Create command = new UserCommand.Create("userId", null, "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", nullEmail, "1996-08-16", Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -117,11 +118,11 @@ class UserTest {
         @Test
         void throwBadRequestException_whenEmailIsEmpty() {
             // arrange
-            String emptyEmail = "";
+            UserCommand.Create command = new UserCommand.Create("userId", "", "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", emptyEmail, "1996-08-16", Gender.MALE, 0);
+               User.of(command);
             });
 
             // assert
@@ -132,11 +133,11 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenEmailContainsInvalidChars() {
             // arrange
-            String invalidEmail = "dd@dd";
+            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "edd@d", "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", invalidEmail, "1996-08-16", Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -147,11 +148,11 @@ class UserTest {
         @Test
         void throwBadRequestException_whenBirthDateIsNull() {
             // arrange
-            String nullBirthDate = null;
+            UserCommand.Create command = new UserCommand.Create("userId", "email@gmail.com", null, Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", nullBirthDate, Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -162,11 +163,11 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenBirthDateFormatIsInvalid() {
             // arrange
-            String invalidBirthDate = "1996/08/16";
+            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "email@gmail.com", "1996/08/16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", invalidBirthDate,Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -177,11 +178,11 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenBirthDateHasInvalidMonth() {
             // arrange
-            String invalidBirthDate = "1996-13-01";
+            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "email@gmail.com", "1996-13-01", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -192,11 +193,11 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenBirthDateHasInvalidDay() {
             // arrange
-            String invalidBirthDate = "1996-02-31";
+            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "email@gmail.com", "1996-02-31", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE, 0);
+                User.of(command);
             });
 
             // assert
@@ -215,7 +216,9 @@ class UserTest {
             String email = "test@gmail.com";
             String birthDate = "1996-08-16";
             Gender gender = Gender.MALE;
-            User user = new User(userId, email, birthDate, gender, 0);
+            UserCommand.Create command = new UserCommand.Create(userId, email, birthDate, gender);
+
+            User user = User.of(command);
 
             // act
             CoreException negativeException = assertThrows(CoreException.class, () -> {

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -133,7 +133,7 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenEmailContainsInvalidChars() {
             // arrange
-            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "edd@d", "1996-08-16", Gender.MALE);
+            UserCommand.Create command = new UserCommand.Create("userId", "edd@d", "1996-08-16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
@@ -163,7 +163,7 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenBirthDateFormatIsInvalid() {
             // arrange
-            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "email@gmail.com", "1996/08/16", Gender.MALE);
+            UserCommand.Create command = new UserCommand.Create("userId", "email@gmail.com", "1996/08/16", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
@@ -178,7 +178,7 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenBirthDateHasInvalidMonth() {
             // arrange
-            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "email@gmail.com", "1996-13-01", Gender.MALE);
+            UserCommand.Create command = new UserCommand.Create("userId", "email@gmail.com", "1996-13-01", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
@@ -193,7 +193,7 @@ class UserTest {
         @Test
         void throwInvalidInputFormatException_whenBirthDateHasInvalidDay() {
             // arrange
-            UserCommand.Create command = new UserCommand.Create("ㅎuserId", "email@gmail.com", "1996-02-31", Gender.MALE);
+            UserCommand.Create command = new UserCommand.Create("userId", "email@gmail.com", "1996-02-31", Gender.MALE);
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -203,4 +203,34 @@ class UserTest {
             assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
         }
     }
+
+    @DisplayName("포인트를 충전할 때")
+    @Nested
+    class ChargePoint {
+        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
+        @Test
+        void throwInvalidInputFormatException_whenChargePointIsUnderZero() {
+            // arrange
+            String userId = "testUser";
+            String email = "test@gmail.com";
+            String birthDate = "1996-08-16";
+            Gender gender = Gender.MALE;
+            User user = new User(userId, email, birthDate, gender, 0);
+
+            // act
+            CoreException negativeException = assertThrows(CoreException.class, () -> {
+                user.chargePoint(-1);
+            });
+
+            CoreException zeroException = assertThrows(CoreException.class, () -> {
+                user.chargePoint(0);
+            });
+
+            // assert
+            assertAll(
+                    () -> assertThat(negativeException.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT),
+                    () -> assertThat(zeroException.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT)
+            );
+        }
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -26,7 +26,7 @@ class UserTest {
             Gender gender = Gender.MALE;
 
             // act
-            User user = new User(userId, email, birthDateStr, gender);
+            User user = new User(userId, email, birthDateStr, gender, 0);
 
             // assert
             assertAll(
@@ -46,7 +46,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(nullId, "email@gmail.com", "1996-08-16", Gender.MALE);
+                new User(nullId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
             });
 
             // assert
@@ -61,7 +61,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(blankId, "email@gmail.com", "1996-08-16", Gender.MALE);
+                new User(blankId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
             });
 
             // assert
@@ -76,7 +76,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(tooLongUserId, "email@gmail.com", "1996-08-16", Gender.MALE);
+                new User(tooLongUserId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
             });
 
             // assert
@@ -91,7 +91,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User(invalidUserId, "email@gmail.com", "1996-08-16", Gender.MALE);
+                new User(invalidUserId, "email@gmail.com", "1996-08-16", Gender.MALE, 0);
             });
 
             // assert
@@ -106,7 +106,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", nullEmail, "1996-08-16", Gender.MALE);
+                new User("correctId", nullEmail, "1996-08-16", Gender.MALE, 0);
             });
 
             // assert
@@ -121,7 +121,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", emptyEmail, "1996-08-16", Gender.MALE);
+                new User("correctId", emptyEmail, "1996-08-16", Gender.MALE, 0);
             });
 
             // assert
@@ -136,7 +136,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", invalidEmail, "1996-08-16", Gender.MALE);
+                new User("correctId", invalidEmail, "1996-08-16", Gender.MALE, 0);
             });
 
             // assert
@@ -151,7 +151,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", nullBirthDate, Gender.MALE);
+                new User("correctId", "good@email.com", nullBirthDate, Gender.MALE, 0);
             });
 
             // assert
@@ -166,7 +166,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", invalidBirthDate,Gender.MALE);
+                new User("correctId", "good@email.com", invalidBirthDate,Gender.MALE, 0);
             });
 
             // assert
@@ -181,7 +181,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE);
+                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE, 0);
             });
 
             // assert
@@ -196,7 +196,7 @@ class UserTest {
 
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE);
+                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE, 0);
             });
 
             // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -246,8 +246,14 @@ class UserTest {
     @Nested
     class ChargePoint {
         @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
-        @Test
-        void throwInvalidInputFormatException_whenChargePointIsUnderZero() {
+        @ParameterizedTest
+        @ValueSource(ints = {
+                -1000,
+                -100,
+                -1,
+                0
+        })
+        void throwInvalidInputFormatException_whenChargePointIsUnderZero(int invalidAmount) {
             // arrange
             String userId = "testUser";
             String email = "test@gmail.com";
@@ -257,20 +263,12 @@ class UserTest {
 
             User user = User.of(command);
 
-            // act
-            CoreException negativeException = assertThrows(CoreException.class, () -> {
-                user.chargePoint(-1);
+            // act & assert
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                user.chargePoint(invalidAmount);
             });
 
-            CoreException zeroException = assertThrows(CoreException.class, () -> {
-                user.chargePoint(0);
-            });
-
-            // assert
-            assertAll(
-                    () -> assertThat(negativeException.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT),
-                    () -> assertThat(zeroException.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT)
-            );
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,0 +1,206 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+
+    @DisplayName("회원(User)을 생성할 때, ")
+    @Nested
+    class Create {
+        @DisplayName("올바른 형식(영문 및 숫자 10자 이내)의 ID, 올바른 형식(xx@yy.zz)의 이메일, 올바른 형식(yyyy-MM-dd)의 생년월일이 주어지면 정상적으로 생성된다.")
+        @Test
+        void createUser_whenCorrectIdEmailAndBirthdayProvided() {
+            // arrange
+            String userId = "correctId";
+            String email = "goodEmail@gmail.com";
+            String birthDateStr = "1996-08-16";
+            Gender gender = Gender.MALE;
+
+            // act
+            User user = new User(userId, email, birthDateStr, gender);
+
+            // assert
+            assertAll(
+                    () -> assertThat(user.getId()).isNotNull(),
+                    () -> assertThat(user.getUserId()).isEqualTo(userId),
+                    () -> assertThat(user.getEmail()).isEqualTo(email),
+                    () -> assertThat(user.getBirthDate()).isEqualTo(LocalDate.parse(birthDateStr)),
+                    () -> assertThat(user.getGender()).isEqualTo(gender)
+            );
+        }
+
+        @DisplayName("ID가 null일 경우 User 객체 생성에 실패하고 BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenUserIdIsNull() {
+            // arrange
+            String nullId = null;
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User(nullId, "email@gmail.com", "1996-08-16", Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("ID가 빈 칸일 경우 User 객체 생성에 실패하고 BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenUserIdIsEmpty() {
+            // arrange
+            String blankId = "";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User(blankId, "email@gmail.com", "1996-08-16", Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("ID가 10자를 초과할 경우 User 객체 생성에 실패하고 INVALID_INPUT_FORMAT 예외가 발생한다.")
+        @Test
+        void throwInvalidInputFormatException_whenUserIdIsTooLong() {
+            // arrange
+            String tooLongUserId = "tooLongUserId";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User(tooLongUserId, "email@gmail.com", "1996-08-16", Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
+        }
+
+        @DisplayName("ID에 영문 및 숫자 이외의 문자가 포함 되었을 경우 User 객체 생성에 실패하고 INVALID_INPUT_FORMAT 예외가 발생한다.")
+        @Test
+        void throwInvalidInputFormatException_whenUserIdContainsInvalidChars() {
+            // arrange
+            String invalidUserId = "ㅎuserId";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User(invalidUserId, "email@gmail.com", "1996-08-16", Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
+        }
+
+        @DisplayName("이메일에 null이 들어올 경우 User 객체 생성에 실패하고 BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenEmailIsNull() {
+            // arrange
+            String nullEmail = null;
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User("correctId", nullEmail, "1996-08-16", Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("이메일에 비어있을 경우 User 객체 생성에 실패하고 BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenEmailIsEmpty() {
+            // arrange
+            String emptyEmail = "";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User("correctId", emptyEmail, "1996-08-16", Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("올바르지 않은 이메일 형식이 들어올 경우 User 객체 생성에 실패하고 INVALID_INPUT_FORMAT 예외가 발생한다.")
+        @Test
+        void throwInvalidInputFormatException_whenEmailContainsInvalidChars() {
+            // arrange
+            String invalidEmail = "dd@dd";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User("correctId", invalidEmail, "1996-08-16", Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
+        }
+
+        @DisplayName("생년월일이 null일 경우 User 객체 생성에 실패하고 BAD_REQUEST 예외가 발생한다.")
+        @Test
+        void throwBadRequestException_whenBirthDateIsNull() {
+            // arrange
+            String nullBirthDate = null;
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User("correctId", "good@email.com", nullBirthDate, Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("생년월일이 yyyy-MM-dd 형식이 아닐 경우 User 객체 생성에 실패하고 INVALID_INPUT_FORMAT 예외가 발생한다.")
+        @Test
+        void throwInvalidInputFormatException_whenBirthDateFormatIsInvalid() {
+            // arrange
+            String invalidBirthDate = "1996/08/16";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User("correctId", "good@email.com", invalidBirthDate,Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
+        }
+
+        @DisplayName("존재하지 않는 월로 생년월일을 입력할 경우 User 객체 생성에 실패하고 INVALID_INPUT_FORMAT 예외가 발생한다.")
+        @Test
+        void throwInvalidInputFormatException_whenBirthDateHasInvalidMonth() {
+            // arrange
+            String invalidBirthDate = "1996-13-01";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
+        }
+
+        @DisplayName("존재하지 않는 날짜로 생년월일을 입력할 경우 User 객체 생성에 실패하고 INVALID_INPUT_FORMAT 예외가 발생한다.")
+        @Test
+        void throwInvalidInputFormatException_whenBirthDateHasInvalidDay() {
+            // arrange
+            String invalidBirthDate = "1996-02-31";
+
+            // act
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                new User("correctId", "good@email.com", invalidBirthDate, Gender.MALE);
+            });
+
+            // assert
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.INVALID_INPUT_FORMAT);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1E2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1E2ETest.java
@@ -1,0 +1,147 @@
+package com.loopers.interfaces.api;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+class PointV1E2ETest {
+    private static final String ENDPOINT = "/api/v1/points";
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public PointV1E2ETest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp, UserRepository userRepository) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+        this.userRepository = userRepository;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("GET /api/v1/points")
+    @Nested
+    class GetPoints {
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnUserPoint_whenUserExists() {
+            // arrange
+            String userId = "testUser";
+            User savedUser = userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response =
+                    testRestTemplate.exchange(
+                            ENDPOINT,
+                            HttpMethod.GET,
+                            new HttpEntity<>(null, headers),
+                            responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertEquals(userId, response.getBody().data().userId()),
+                    () -> assertEquals(savedUser.getPoint(), response.getBody().data().point())
+            );
+        }
+
+        @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void return400BadRequest_whenNotGivenUserId() {
+            // arrange
+
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.GET,
+                    new HttpEntity<>(null),
+                    responseType);
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @DisplayName("포인트 충전 요청이 왔을 때")
+    @Nested
+    class ChargePoint {
+        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
+        @Test
+        void returnUserIdAndPoint_whenUserExists() {
+            // arrange
+            String userId = "testUser";
+            User savedUser = userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+
+            UserV1Dto.UserPointChargeRequest request = new UserV1Dto.UserPointChargeRequest(1_000);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response =
+                    testRestTemplate.exchange(
+                            ENDPOINT,
+                            HttpMethod.POST,
+                            new HttpEntity<>(request, headers),
+                            responseType
+                    );
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertEquals(response.getBody().data().userId(), savedUser.getUserId()),
+                    () -> assertThat(response.getBody().data().point()).isEqualTo(1_000)
+            );
+        }
+
+        @DisplayName("존재하지 않는 유저로 요청할 경우, `404 Not Found` 응답을 반환한다.")
+        @Test
+        void return404NotFound_whenProvidedNonExistsUserId() {
+            // arrange
+            String nonExistsUserId = "nonExistsUser";
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", nonExistsUserId);
+            UserV1Dto.UserPointChargeRequest request = new UserV1Dto.UserPointChargeRequest(1_000);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request, headers),
+                    responseType
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getBody().meta().errorCode()).isEqualTo(ErrorType.USER_NOT_FOUND.getCode());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1E2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/PointV1E2ETest.java
@@ -143,5 +143,89 @@ class PointV1E2ETest {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
             assertThat(response.getBody().meta().errorCode()).isEqualTo(ErrorType.USER_NOT_FOUND.getCode());
         }
+
+        @DisplayName("0원을 충전 요청할 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void return400BadRequest_whenProvidedZeroAmount() {
+            // arrange
+            String userId = "testUser";
+            userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            
+            UserV1Dto.UserPointChargeRequest request = new UserV1Dto.UserPointChargeRequest(0);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Object>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Object>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request, headers),
+                    responseType
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody().meta().errorCode()).isEqualTo(ErrorType.BAD_REQUEST.getCode());
+            assertThat(response.getBody().meta().message()).contains("충전 금액은 1원 이상이어야 합니다");
+        }
+
+        @DisplayName("음수로 충전 요청할 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void return400BadRequest_whenProvidedNegativeAmount() {
+            // arrange
+            String userId = "testUser";
+            userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            UserV1Dto.UserPointChargeRequest request = new UserV1Dto.UserPointChargeRequest(-100);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Object>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Object>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request, headers),
+                    responseType
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody().meta().errorCode()).isEqualTo(ErrorType.BAD_REQUEST.getCode());
+            assertThat(response.getBody().meta().message()).contains("충전 금액은 1원 이상이어야 합니다");
+        }
+
+        @DisplayName("null 값으로 충전 요청할 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void return400BadRequest_whenProvidedNullAmount() {
+            // arrange
+            String userId = "testUser";
+            userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", userId);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            String request = "{\"amount\": null}";
+
+            // act
+            ParameterizedTypeReference<ApiResponse<Object>> responseType = new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<Object>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request, headers),
+                    responseType
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(response.getBody().meta().errorCode()).isEqualTo(ErrorType.BAD_REQUEST.getCode());
+            assertThat(response.getBody().meta().message()).contains("필수 필드 'amount'이(가) 누락되었습니다");
+        }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
@@ -4,7 +4,6 @@ import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.interfaces.api.user.UserV1Dto;
-import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -146,111 +145,6 @@ class UserV1ApiE2ETest {
 
             // assert
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-        }
-    }
-
-    @DisplayName("GET /api/v1/users/points")
-    @Nested
-    class GetUserPoint {
-        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
-        @Test
-        void returnUserPoint_whenUserExists() {
-            // arrange
-            String userId = "testUser";
-            User savedUser = userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-USER-ID", userId);
-
-            // act
-            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
-            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response =
-                    testRestTemplate.exchange(
-                            ENDPOINT + "/points",
-                            HttpMethod.GET,
-                            new HttpEntity<>(null, headers),
-                            responseType);
-
-            // assert
-            assertAll(
-                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
-                    () -> assertEquals(userId, response.getBody().data().userId()),
-                    () -> assertEquals(savedUser.getPoint(), response.getBody().data().point())
-            );
-        }
-
-        @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.")
-        @Test
-        void return400BadRequest_whenNotGivenUserId() {
-            // arrange
-
-
-            // act
-            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
-            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response = testRestTemplate.exchange(
-                    ENDPOINT + "/points",
-                    HttpMethod.GET,
-                    new HttpEntity<>(null),
-                    responseType);
-
-            // assert
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        }
-    }
-
-    @DisplayName("포인트 충전 요청이 왔을 때")
-    @Nested
-    class ChargePoint {
-        @DisplayName("존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.")
-        @Test
-        void returnUserIdAndPoint_whenUserExists() {
-            // arrange
-            String userId = "testUser";
-            User savedUser = userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-USER-ID", userId);
-
-            UserV1Dto.UserPointChargeRequest request = new UserV1Dto.UserPointChargeRequest(1_000);
-
-            // act
-            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
-            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response =
-                    testRestTemplate.exchange(
-                            ENDPOINT + "/points",
-                            HttpMethod.POST,
-                            new HttpEntity<>(request, headers),
-                            responseType
-                    );
-
-            // assert
-            assertAll(
-                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
-                    () -> assertEquals(response.getBody().data().userId(), savedUser.getUserId()),
-                    () -> assertThat(response.getBody().data().point()).isEqualTo(1_000)
-            );
-        }
-
-        @DisplayName("존재하지 않는 유저로 요청할 경우, `404 Not Found` 응답을 반환한다.")
-        @Test
-        void return404NotFound_whenProvidedNonExistsUserId() {
-            // arrange
-            String nonExistsUserId = "nonExistsUser";
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("X-USER-ID", nonExistsUserId);
-            UserV1Dto.UserPointChargeRequest request = new UserV1Dto.UserPointChargeRequest(1_000);
-
-            // act
-            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserPointResponse>> responseType = new ParameterizedTypeReference<>() {};
-            ResponseEntity<ApiResponse<UserV1Dto.UserPointResponse>> response = testRestTemplate.exchange(
-                    ENDPOINT + "/points",
-                    HttpMethod.POST,
-                    new HttpEntity<>(request, headers),
-                    responseType
-            );
-
-            // assert
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-            assertThat(response.getBody().meta().errorCode()).isEqualTo(ErrorType.USER_NOT_FOUND.getCode());
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
@@ -1,0 +1,101 @@
+package com.loopers.interfaces.api;
+
+import com.loopers.domain.user.Gender;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class UserV1ApiE2ETest {
+    private static final String ENDPOINT_REGISTER = "/api/v1/users";
+
+    private final TestRestTemplate testRestTemplate;
+    private final DatabaseCleanUp databaseCleanUp;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    public UserV1ApiE2ETest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.databaseCleanUp = databaseCleanUp;
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class RegisterUser {
+        @DisplayName("회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnUser_whenRegisterUser() {
+            // arrange
+            UserV1Dto.UserRegisterRequest request = new UserV1Dto.UserRegisterRequest(
+                    "testUser",
+                    "test@gmail.com",
+                    "1996-08-16",
+                    Gender.MALE
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(ENDPOINT_REGISTER, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            // assert
+            assertAll(
+                    () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
+                    () -> assertNotNull(response.getBody()),
+                    () -> assertEquals(request.userId(), response.getBody().data().userId()),
+                    () -> assertEquals(request.email(), response.getBody().data().email()),
+                    () -> {
+                        LocalDate expectedDate = LocalDate.parse(request.birthDate());
+                        assertThat(response.getBody().data().birthDate()).isEqualTo(expectedDate);
+                    },
+                    () -> assertEquals(request.gender(), response.getBody().data().gender())
+            );
+        }
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void return400BadRequest_whenNotGivenGenderForRegisterUser() {
+            // arrange
+            UserV1Dto.UserRegisterRequest request = new UserV1Dto.UserRegisterRequest(
+                    "testUser",
+                    "test@gmail.com",
+                    "1996-08-16",
+                    null
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {
+            };
+            ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
+                    testRestTemplate.exchange(ENDPOINT_REGISTER, HttpMethod.POST, new HttpEntity<>(request), responseType);
+
+            // assert
+            assertTrue(response.getStatusCode().is4xxClientError());
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
@@ -113,7 +113,7 @@ class UserV1ApiE2ETest {
             ParameterizedTypeReference<ApiResponse<UserV1Dto.UserResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
                     testRestTemplate.exchange(
-                            ENDPOINT,
+                            ENDPOINT + "/me",
                             HttpMethod.GET,
                             new HttpEntity<>(null, headers),
                             responseType);
@@ -138,7 +138,7 @@ class UserV1ApiE2ETest {
                     new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.UserResponse>> response =
                     testRestTemplate.exchange(
-                            ENDPOINT,
+                            ENDPOINT + "/me",
                             HttpMethod.GET,
                             new HttpEntity<>(null, headers),
                             responseType);

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/UserV1ApiE2ETest.java
@@ -2,6 +2,7 @@ package com.loopers.interfaces.api;
 
 import com.loopers.domain.user.Gender;
 import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.interfaces.api.user.UserV1Dto;
 import com.loopers.utils.DatabaseCleanUp;
@@ -47,7 +48,7 @@ class UserV1ApiE2ETest {
         @Test
         void returnUser_whenRegisterUser() {
             // arrange
-            UserV1Dto.UserRegisterRequest request = new UserV1Dto.UserRegisterRequest(
+            UserV1Dto.UserSignUpRequest request = new UserV1Dto.UserSignUpRequest(
                     "testUser",
                     "test@gmail.com",
                     "1996-08-16",
@@ -78,7 +79,7 @@ class UserV1ApiE2ETest {
         @Test
         void return400BadRequest_whenNotGivenGenderForRegisterUser() {
             // arrange
-            UserV1Dto.UserRegisterRequest request = new UserV1Dto.UserRegisterRequest(
+            UserV1Dto.UserSignUpRequest request = new UserV1Dto.UserSignUpRequest(
                     "testUser",
                     "test@gmail.com",
                     "1996-08-16",
@@ -105,7 +106,7 @@ class UserV1ApiE2ETest {
         void returnUser_whenGetUser() {
             // arrange
             String userId = "testUser";
-            User savedUser = userRepository.save(new User(userId, "test@gmail.com", "1996-08-16", Gender.MALE, 0));
+            User savedUser = userRepository.save(User.of(new UserCommand.Create(userId, "test@gmail.com", "1996-08-16", Gender.MALE)));
             HttpHeaders headers = new HttpHeaders();
             headers.set("X-USER-ID", userId);
 


### PR DESCRIPTION
## 📌 Summary
### 기능구현
+ User
  + 회원가입
  + 내 정보 조회
  + 포인트 조회
  + 포인트 충전

## 💬 Review Points

### 포인트 도메인 분리에 대한 설계 고민
+ 제가 생각했을 때 포인트는 `User` 도메인에 종속적이고 현재는 포인트 자체의 역할이 크지 않다고 생각해서 `User` 엔티티의 필드로 두었습니다.
  + [User.java](https://github.com/beurre-noisette/loopers/blob/feat/round-1-quest/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java)

+ `UserV1Controller`에서 포인트 관련 요청을 처리하고 있으며, 사용자 식별을 `@RequestHeader("X-USER-ID")`로 받고 있습니다. 이로 인해
  `/users/points` 형태의 URL이 특정 사용자를 명시하지 않아 RESTful 하지 못하다는 생각이 있습니다.
  + [UserV1Controller](https://github.com/beurre-noisette/loopers/blob/feat/round-1-quest/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java)

## ✅ Checklist

+ [v] 테스트는 모두 통과해야 하며, `@Test` 기반으로 명시적으로 작성
+ [v] 각 테스트는 테스트 명/설명/입력/예상 결과가 분명해야 함
+ [v] E2E 테스트는 실제 HTTP 요청을 통해 흐름을 검증할 것