### PR TITLE
Feat/round 9

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductQueryRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductQueryRepository {
@@ -11,6 +12,8 @@ public interface ProductQueryRepository {
     Page<ProductQueryData> findProducts(Long brandId, ProductSortType sortType, Pageable pageable);
     
     Optional<ProductDetailQueryData> findProductDetailById(Long productId);
+    
+    List<ProductQueryData> findProductsByIds(List<Long> productIds);
     
     record ProductQueryData(
         Long id,

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingQuery.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingQuery.java
@@ -1,0 +1,147 @@
+package com.loopers.application.ranking;
+
+import com.loopers.application.product.ProductQueryRepository;
+import com.loopers.domain.ranking.RankingService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class RankingQuery {
+    
+    private final RankingService rankingService;
+    private final ProductQueryRepository productQueryRepository;
+
+    @Autowired
+    public RankingQuery(RankingService rankingService, ProductQueryRepository productQueryRepository) {
+        this.rankingService = rankingService;
+        this.productQueryRepository = productQueryRepository;
+    }
+
+    public RankingPageResult getRankings(String dateStr, int page, int size) {
+        LocalDate date = parseDate(dateStr);
+        
+        // Redis에서 순서가 보장된 랭킹 데이터 조회
+        Set<ZSetOperations.TypedTuple<String>> sortedRankingsFromRedis = 
+                rankingService.getRankingsWithPaging(date, page, size);
+        
+        if (sortedRankingsFromRedis == null || sortedRankingsFromRedis.isEmpty()) {
+            log.info("랭킹 데이터가 없습니다 - date: {}, page: {}, size: {}", date, page, size);
+            return new RankingPageResult(
+                    Collections.emptyList(),
+                    0L,
+                    0,
+                    page,
+                    size,
+                    date.format(DateTimeFormatter.ISO_LOCAL_DATE)
+            );
+        }
+        
+        // DB 조회를 위한 productId 리스트 추출
+        List<Long> productIdsForDbQuery = sortedRankingsFromRedis.stream()
+                .map(tuple -> RankingService.extractProductId(tuple.getValue()))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        
+        // DB에서 상품 정보 일괄 조회 후 빠른 검색을 위해 Map으로 변환
+        Map<Long, ProductQueryRepository.ProductQueryData> productInfoById = 
+                productQueryRepository.findProductsByIds(productIdsForDbQuery)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                ProductQueryRepository.ProductQueryData::id,
+                                product -> product
+                        ));
+        
+        // 페이징에 따른 시작 순위 계산
+        long startRank = (long) page * size + 1;
+
+        // Redis 순서를 유지하며 최종 랭킹 데이터 조합
+        List<RankingItem> rankedItemsWithProductInfo = new ArrayList<>();
+        long currentRank = startRank;
+
+        for (ZSetOperations.TypedTuple<String> redisRankingEntry : sortedRankingsFromRedis) {
+            Long productId = RankingService.extractProductId(redisRankingEntry.getValue());
+            if (productId != null) {
+                ProductQueryRepository.ProductQueryData productInfo = productInfoById.get(productId);
+                if (productInfo != null) {
+                    rankedItemsWithProductInfo.add(new RankingItem(
+                            currentRank++,
+                            productId,
+                            productInfo.name(),
+                            productInfo.description(),
+                            productInfo.price(),
+                            productInfo.brandId(),
+                            productInfo.brandName(),
+                            productInfo.likeCount(),
+                            roundScore(redisRankingEntry.getScore())
+                    ));
+                }
+            }
+        }
+        
+        Long totalCount = rankingService.getTotalCount(date);
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+        
+        return new RankingPageResult(
+                rankedItemsWithProductInfo,
+                totalCount,
+                totalPages,
+                page,
+                size,
+                date.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        );
+    }
+
+    private LocalDate parseDate(String dateStr) {
+        if (dateStr == null || dateStr.isEmpty()) {
+            return LocalDate.now();
+        }
+        
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+            return LocalDate.parse(dateStr, formatter);
+        } catch (Exception e) {
+            log.warn("날짜 파싱 실패, 오늘 날짜 사용 - input: {}", dateStr);
+            return LocalDate.now();
+        }
+    }
+    
+    private Double roundScore(Double score) {
+        if (score == null) {
+            return null;
+        }
+        return BigDecimal.valueOf(score)
+                .setScale(2, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+    
+    public record RankingPageResult(
+            List<RankingItem> rankings,
+            long totalElements,
+            int totalPages,
+            int currentPage,
+            int pageSize,
+            String date
+    ) {}
+    
+    public record RankingItem(
+            long rank,
+            Long productId,
+            String productName,
+            String productDescription,
+            BigDecimal price,
+            Long brandId,
+            String brandName,
+            Integer likeCount,
+            Double score
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.ranking;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -23,39 +24,54 @@ public class RankingService {
     }
 
     public Set<ZSetOperations.TypedTuple<String>> getRankingsWithPaging(LocalDate date, int page, int size) {
-        String key = generateKey(date);
-        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
-        
-        long start = (long) page * size;
-        long end = start + size - 1;
-        
-        Set<ZSetOperations.TypedTuple<String>> rankings = 
-                zSetOps.reverseRangeWithScores(key, start, end);
-        
-        log.debug("랭킹 페이지 조회 - key: {}, page: {}, size: {}, results: {}", 
-                key, page, size, rankings != null ? rankings.size() : 0);
-        
-        return rankings;
+        try {
+            String key = generateKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+            
+            long start = (long) page * size;
+            long end = start + size - 1;
+            
+            Set<ZSetOperations.TypedTuple<String>> rankings = 
+                    zSetOps.reverseRangeWithScores(key, start, end);
+            
+            log.debug("랭킹 페이지 조회 - key: {}, page: {}, size: {}, results: {}", 
+                    key, page, size, rankings != null ? rankings.size() : 0);
+            
+            return rankings;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 연결 실패로 랭킹 조회 불가 - date: {}, page: {}, size: {}", date, page, size);
+            return null;
+        }
     }
     
     public Long getProductRank(Long productId, LocalDate date) {
-        String key = generateKey(date);
-        String member = generateMember(productId);
-        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
-        
-        Long rank = zSetOps.reverseRank(key, member);
-        
-        log.debug("상품 순위 조회 - key: {}, productId: {}, rank: {}", 
-                key, productId, rank != null ? rank + 1 : null);
-        
-        return rank != null ? rank + 1 : null;
+        try {
+            String key = generateKey(date);
+            String member = generateMember(productId);
+            ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+            
+            Long rank = zSetOps.reverseRank(key, member);
+            
+            log.debug("상품 순위 조회 - key: {}, productId: {}, rank: {}", 
+                    key, productId, rank != null ? rank + 1 : null);
+            
+            return rank != null ? rank + 1 : null;
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 연결 실패로 상품 순위 조회 불가 - productId: {}", productId);
+            return null;
+        }
     }
 
     public Long getTotalCount(LocalDate date) {
-        String key = generateKey(date);
-        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
-        
-        return zSetOps.zCard(key);
+        try {
+            String key = generateKey(date);
+            ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+            
+            return zSetOps.zCard(key);
+        } catch (RedisConnectionFailureException e) {
+            log.warn("Redis 연결 실패로 전체 카운트 조회 불가 - date: {}", date);
+            return 0L;
+        }
     }
     
     private String generateKey(LocalDate date) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,80 @@
+package com.loopers.domain.ranking;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+
+@Slf4j
+@Service
+public class RankingService {
+    
+    private static final String KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    
+    private final RedisTemplate<String, String> redisTemplate;
+    
+    public RankingService(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public Set<ZSetOperations.TypedTuple<String>> getRankingsWithPaging(LocalDate date, int page, int size) {
+        String key = generateKey(date);
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        
+        long start = (long) page * size;
+        long end = start + size - 1;
+        
+        Set<ZSetOperations.TypedTuple<String>> rankings = 
+                zSetOps.reverseRangeWithScores(key, start, end);
+        
+        log.debug("랭킹 페이지 조회 - key: {}, page: {}, size: {}, results: {}", 
+                key, page, size, rankings != null ? rankings.size() : 0);
+        
+        return rankings;
+    }
+    
+    public Long getProductRank(Long productId, LocalDate date) {
+        String key = generateKey(date);
+        String member = generateMember(productId);
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        
+        Long rank = zSetOps.reverseRank(key, member);
+        
+        log.debug("상품 순위 조회 - key: {}, productId: {}, rank: {}", 
+                key, productId, rank != null ? rank + 1 : null);
+        
+        return rank != null ? rank + 1 : null;
+    }
+
+    public Long getTotalCount(LocalDate date) {
+        String key = generateKey(date);
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        
+        return zSetOps.zCard(key);
+    }
+    
+    private String generateKey(LocalDate date) {
+        return KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+    
+    private String generateMember(Long productId) {
+        return "product:" + productId;
+    }
+    
+    public static Long extractProductId(String member) {
+        if (member != null && member.startsWith("product:")) {
+            try {
+                return Long.parseLong(member.substring(8));
+            } catch (NumberFormatException e) {
+                log.error("Invalid product member format: {}", member);
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/query/ProductQueryRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/query/ProductQueryRepositoryImpl.java
@@ -93,6 +93,33 @@ public class ProductQueryRepositoryImpl implements ProductQueryRepository {
 
         return Optional.ofNullable(result);
     }
+    
+    @Override
+    public List<ProductQueryData> findProductsByIds(List<Long> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            return List.of();
+        }
+        
+        return jpaQueryFactory
+            .select(Projections.constructor(ProductQueryData.class,
+                product.id,
+                product.name,
+                product.description,
+                product.price,
+                product.stock,
+                brand.id,
+                brand.name,
+                product.likeCount
+            ))
+            .from(product)
+            .join(product.brand, brand)
+            .where(
+                product.id.in(productIds),
+                product.deletedAt.isNull(),
+                brand.deletedAt.isNull()
+            )
+            .fetch();
+    }
 
     private static BooleanExpression brandIdEq(Long brandId) {
         return brandId != null ? product.brand.id.eq(brandId) : null;

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingQuery;
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/rankings")
+public class RankingV1Controller {
+    
+    private final RankingQuery rankingQuery;
+
+    @Autowired
+    public RankingV1Controller(RankingQuery rankingQuery) {
+        this.rankingQuery = rankingQuery;
+    }
+
+    @GetMapping
+    public ApiResponse<RankingQuery.RankingPageResult> getRankings(
+            @RequestParam(required = false) String date,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        RankingQuery.RankingPageResult result = rankingQuery.getRankings(date, page, size);
+
+        return ApiResponse.success(result);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/event/OrderCompletionListenerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/event/OrderCompletionListenerTest.java
@@ -63,7 +63,7 @@ class OrderCompletionListenerTest {
             testOrder.processingPayment();
             
             when(orderService.findById(testOrder.getId())).thenReturn(testOrder);
-            doNothing().when(stockReservationService).confirmReservation(testOrder.getId());
+            when(stockReservationService.confirmReservation(testOrder.getId())).thenReturn(List.of());
             
             PaymentCompletedEvent event = PaymentCompletedEvent.of(
                     "correlation-123",
@@ -108,7 +108,7 @@ class OrderCompletionListenerTest {
             testOrder.processingPayment();
             
             when(orderService.findById(testOrder.getId())).thenReturn(testOrder);
-            doNothing().when(stockReservationService).releaseReservation(testOrder.getId());
+            when(stockReservationService.releaseReservation(testOrder.getId())).thenReturn(List.of());
             
             PaymentFailedEvent event = PaymentFailedEvent.of(
                     "correlation-456",

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductQueryTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductQueryTest.java
@@ -1,5 +1,6 @@
 package com.loopers.application.product;
 
+import com.loopers.domain.ranking.RankingService;
 import com.loopers.infrastructure.kafka.KafkaEventPublisher;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -39,6 +40,9 @@ class ProductQueryTest {
     @Mock
     private KafkaEventPublisher kafkaEventPublisher;
 
+    @Mock
+    private RankingService rankingService;
+
     private ProductQuery productQuery;
 
     @BeforeEach
@@ -46,7 +50,8 @@ class ProductQueryTest {
         productQuery = new ProductQuery(
                 productQueryRepository,
                 productQueryCacheRepository,
-                kafkaEventPublisher
+                kafkaEventPublisher,
+                rankingService
         );
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/ranking/RankingServiceIntegrationTest.java
@@ -1,0 +1,139 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+class RankingServiceIntegrationTest {
+    
+    @Autowired
+    private RankingService rankingService;
+    
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+    
+    @Autowired
+    private RedisCleanUp redisCleanUp;
+    
+    private final LocalDate testDate = LocalDate.of(2025, 1, 11);
+    
+    @AfterEach
+    void tearDown() {
+        redisCleanUp.truncateAll();
+    }
+    
+    @DisplayName("랭킹 데이터 준비")
+    @BeforeEach
+    void setUpRankingData() {
+        // Redis에 직접 테스트 데이터 설정
+        String key = "ranking:all:" + testDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        
+        zSetOps.add(key, "product:1", 100.0);
+        zSetOps.add(key, "product:2", 80.0);
+        zSetOps.add(key, "product:3", 60.0);
+        zSetOps.add(key, "product:4", 40.0);
+        zSetOps.add(key, "product:5", 20.0);
+    }
+    
+    @DisplayName("랭킹 조회 시")
+    @Nested
+    class GetRankings {
+        
+        @DisplayName("페이징된 랭킹 목록이 점수 내림차순으로 반환된다")
+        @Test
+        void returnPagedRankingsInDescOrder_whenGetRankingsWithPaging() {
+            // arrange & act
+            Set<ZSetOperations.TypedTuple<String>> rankings = 
+                rankingService.getRankingsWithPaging(testDate, 0, 3);
+            
+            // assert
+            assertThat(rankings).hasSize(3);
+            
+            Double previousScore = null;
+            for (ZSetOperations.TypedTuple<String> tuple : rankings) {
+                if (previousScore != null) {
+                    assertThat(tuple.getScore()).isLessThan(previousScore);
+                }
+                previousScore = tuple.getScore();
+            }
+        }
+        
+        @DisplayName("특정 상품의 순위가 정확히 반환된다")
+        @Test
+        void returnCorrectRank_whenGetProductRank() {
+            // arrange & act
+            Long rank1 = rankingService.getProductRank(1L, testDate);
+            Long rank3 = rankingService.getProductRank(3L, testDate);
+            Long rank5 = rankingService.getProductRank(5L, testDate);
+            
+            // assert
+            assertAll(
+                () -> assertThat(rank1).isEqualTo(1L),
+                () -> assertThat(rank3).isEqualTo(3L),
+                () -> assertThat(rank5).isEqualTo(5L)
+            );
+        }
+        
+        @DisplayName("랭킹에 없는 상품 조회 시 null이 반환된다")
+        @Test
+        void returnNull_whenProductNotInRanking() {
+            // arrange & act
+            Long rank = rankingService.getProductRank(999L, testDate);
+
+            // assert
+            assertThat(rank).isNull();
+        }
+        
+        @DisplayName("전체 랭킹 개수가 정확히 반환된다")
+        @Test
+        void returnCorrectTotalCount_whenGetTotalCount() {
+            // arrange & act
+            Long count = rankingService.getTotalCount(testDate);
+            
+            // assert
+            assertThat(count).isEqualTo(5L);
+        }
+    }
+    
+    @DisplayName("날짜별 키 관리 시")
+    @Nested
+    class DateBasedKeyManagement {
+        
+        @DisplayName("서로 다른 날짜의 랭킹은 독립적으로 조회된다")
+        @Test
+        void queryRankingsIndependently_whenDifferentDates() {
+            // arrange
+            LocalDate today = LocalDate.of(2025, 1, 11);
+            LocalDate tomorrow = LocalDate.of(2025, 1, 12);
+            
+            // Redis에 다른 날짜 데이터 설정
+            String tomorrowKey = "ranking:all:" + tomorrow.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+            zSetOps.add(tomorrowKey, "product:100", 50.0);
+            
+            // act
+            Long todayRank = rankingService.getProductRank(1L, today);
+            Long tomorrowRank = rankingService.getProductRank(100L, tomorrow);
+            Long todayRankFor100 = rankingService.getProductRank(100L, today);
+            
+            // assert
+            assertAll(
+                () -> assertThat(todayRank).isEqualTo(1L),  // 오늘 날짜의 1번 상품은 1위
+                () -> assertThat(tomorrowRank).isEqualTo(1L),  // 내일 날짜의 100번 상품은 1위
+                () -> assertThat(todayRankFor100).isNull()  // 오늘 날짜에는 100번 상품 없음
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/RankingV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/RankingV1ApiE2ETest.java
@@ -1,0 +1,277 @@
+package com.loopers.interfaces.api;
+
+import com.loopers.application.product.ProductQuery;
+import com.loopers.application.ranking.RankingQuery;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandCommand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductCommand;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import com.loopers.utils.RedisCleanUp;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.http.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RankingV1ApiE2ETest {
+    
+    private static final String RANKINGS_ENDPOINT = "/api/v1/rankings";
+    private static final String PRODUCTS_ENDPOINT = "/api/v1/products";
+    
+    private final TestRestTemplate testRestTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ProductRepository productRepository;
+    private final BrandRepository brandRepository;
+    private final DatabaseCleanUp databaseCleanUp;
+    private final RedisCleanUp redisCleanUp;
+    
+    @Autowired
+    public RankingV1ApiE2ETest(TestRestTemplate testRestTemplate,
+                               RedisTemplate<String, String> redisTemplate,
+                               ProductRepository productRepository,
+                               BrandRepository brandRepository,
+                               DatabaseCleanUp databaseCleanUp,
+                               RedisCleanUp redisCleanUp) {
+        this.testRestTemplate = testRestTemplate;
+        this.redisTemplate = redisTemplate;
+        this.productRepository = productRepository;
+        this.brandRepository = brandRepository;
+        this.databaseCleanUp = databaseCleanUp;
+        this.redisCleanUp = redisCleanUp;
+    }
+    
+    private Brand testBrand;
+    private Product product1;
+    private Product product2;
+    private Product product3;
+    private final LocalDate testDate = LocalDate.now();
+    private final String testDateStr = testDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+    
+    @BeforeEach
+    void setUp() {
+        // 테스트 브랜드 생성
+        BrandCommand.Create brandCommand = new BrandCommand.Create("테스트브랜드", "브랜드설명");
+        testBrand = brandRepository.save(Brand.of(brandCommand));
+        
+        // 테스트 상품 생성
+        ProductCommand.Create productCommand1 = new ProductCommand.Create(
+            "상품1", "설명1", BigDecimal.valueOf(10000), 100, testBrand.getId()
+        );
+        product1 = productRepository.save(Product.of(productCommand1, testBrand));
+        
+        ProductCommand.Create productCommand2 = new ProductCommand.Create(
+            "상품2", "설명2", BigDecimal.valueOf(20000), 200, testBrand.getId()
+        );
+        product2 = productRepository.save(Product.of(productCommand2, testBrand));
+        
+        ProductCommand.Create productCommand3 = new ProductCommand.Create(
+            "상품3", "설명3", BigDecimal.valueOf(30000), 300, testBrand.getId()
+        );
+        product3 = productRepository.save(Product.of(productCommand3, testBrand));
+        
+        // 테스트용 랭킹 데이터를 Redis에 직접 설정
+        String rankingKey = "ranking:all:" + testDateStr;
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        zSetOps.add(rankingKey, "product:" + product1.getId(), 100.0);
+        zSetOps.add(rankingKey, "product:" + product2.getId(), 80.0);
+        zSetOps.add(rankingKey, "product:" + product3.getId(), 60.0);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+        redisCleanUp.truncateAll();
+    }
+    
+    @DisplayName("랭킹 조회 API 테스트")
+    @Nested
+    class GetRankings {
+        
+        @DisplayName("날짜 파라미터 없이 요청하면 오늘 날짜의 랭킹을 반환한다")
+        @Test
+        void returnTodayRankings_whenNoDateParameter() {
+            // arrange & act
+            ResponseEntity<ApiResponse<RankingQuery.RankingPageResult>> response = testRestTemplate.exchange(
+                RANKINGS_ENDPOINT,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+            );
+            
+            // assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody()).isNotNull(),
+                () -> assertThat(response.getBody().data()).isNotNull(),
+                () -> assertThat(response.getBody().data().rankings()).hasSize(3),
+                () -> assertThat(response.getBody().data().rankings().get(0).rank()).isEqualTo(1),
+                () -> assertThat(response.getBody().data().rankings().get(0).productId()).isEqualTo(product1.getId()),
+                () -> assertThat(response.getBody().data().rankings().get(0).productName()).isEqualTo("상품1"),
+                () -> assertThat(response.getBody().data().totalElements()).isEqualTo(3),
+                () -> assertThat(response.getBody().data().date()).isEqualTo(testDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
+            );
+        }
+        
+        @DisplayName("특정 날짜의 랭킹을 조회할 수 있다")
+        @Test
+        void returnSpecificDateRankings_whenDateParameterProvided() {
+            // arrange & act
+            String url = RANKINGS_ENDPOINT + "?date=" + testDateStr;
+            ResponseEntity<ApiResponse<RankingQuery.RankingPageResult>> response = testRestTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<ApiResponse<RankingQuery.RankingPageResult>>() {}
+            );
+            
+            // assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody().data().rankings()).hasSize(3),
+                () -> assertThat(response.getBody().data().date()).isEqualTo(testDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
+            );
+        }
+        
+        @DisplayName("페이징 파라미터가 동작한다")
+        @Test
+        void applyPaging_whenPageParametersProvided() {
+            // arrange & act
+            String url = RANKINGS_ENDPOINT + "?page=0&size=2";
+            ResponseEntity<ApiResponse<RankingQuery.RankingPageResult>> response = testRestTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<ApiResponse<RankingQuery.RankingPageResult>>() {}
+            );
+            
+            // assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody().data().rankings()).hasSize(2),
+                () -> assertThat(response.getBody().data().pageSize()).isEqualTo(2),
+                () -> assertThat(response.getBody().data().currentPage()).isEqualTo(0),
+                () -> assertThat(response.getBody().data().rankings().get(0).rank()).isEqualTo(1),
+                () -> assertThat(response.getBody().data().rankings().get(1).rank()).isEqualTo(2)
+            );
+        }
+        
+        @DisplayName("두 번째 페이지를 조회하면 순위가 이어진다")
+        @Test
+        void continueRanking_whenSecondPageRequested() {
+            // arrange & act
+            String url = RANKINGS_ENDPOINT + "?page=1&size=2";
+            ResponseEntity<ApiResponse<RankingQuery.RankingPageResult>> response = testRestTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+            );
+            
+            // assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody().data().rankings()).hasSize(1),
+                () -> assertThat(response.getBody().data().rankings().get(0).rank()).isEqualTo(3),
+                () -> assertThat(response.getBody().data().rankings().get(0).productId()).isEqualTo(product3.getId())
+            );
+        }
+        
+        @DisplayName("랭킹 데이터가 없는 날짜를 조회하면 빈 배열을 반환한다")
+        @Test
+        void returnEmptyArray_whenNoRankingData() {
+            // arrange
+            LocalDate futureDate = LocalDate.now().plusDays(10);
+            String futureDateStr = futureDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            
+            // act
+            String url = RANKINGS_ENDPOINT + "?date=" + futureDateStr;
+            ResponseEntity<ApiResponse<RankingQuery.RankingPageResult>> response = testRestTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+            );
+            
+            // assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody().data().rankings()).isEmpty(),
+                () -> assertThat(response.getBody().data().totalElements()).isEqualTo(0)
+            );
+        }
+    }
+    
+    @DisplayName("상품 상세 조회 시 랭킹 정보 포함")
+    @Nested
+    class GetProductWithRanking {
+        
+        @DisplayName("랭킹에 있는 상품을 조회하면 순위 정보가 포함된다")
+        @Test
+        void includeRankingInfo_whenProductInRanking() {
+            // arrange
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", "testUser");
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+            
+            // act
+            ResponseEntity<ApiResponse<ProductQuery.ProductDetailResult>> response = testRestTemplate.exchange(
+                PRODUCTS_ENDPOINT + "/" + product1.getId(),
+                HttpMethod.GET,
+                request,
+                new ParameterizedTypeReference<>() {}
+            );
+            
+            // assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody().data().id()).isEqualTo(product1.getId()),
+                () -> assertThat(response.getBody().data().name()).isEqualTo("상품1"),
+                () -> assertThat(response.getBody().data().ranking()).isNotNull(),
+                () -> assertThat(response.getBody().data().ranking().rank()).isEqualTo(1L)
+            );
+        }
+        
+        @DisplayName("랭킹에 없는 상품을 조회하면 ranking이 null이다")
+        @Test
+        void returnNullRanking_whenProductNotInRanking() {
+            // arrange
+            ProductCommand.Create newProductCommand = new ProductCommand.Create(
+                "랭킹없는상품", "설명", BigDecimal.valueOf(50000), 50, testBrand.getId()
+            );
+            Product newProduct = productRepository.save(Product.of(newProductCommand, testBrand));
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-USER-ID", "testUser");
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+            
+            // act
+            ResponseEntity<ApiResponse<ProductQuery.ProductDetailResult>> response = testRestTemplate.exchange(
+                PRODUCTS_ENDPOINT + "/" + newProduct.getId(),
+                HttpMethod.GET,
+                request,
+                new ParameterizedTypeReference<>() {}
+            );
+            
+            // assert
+            assertAll(
+                () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                () -> assertThat(response.getBody().data().id()).isEqualTo(newProduct.getId()),
+                () -> assertThat(response.getBody().data().ranking()).isNull()
+            );
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScorePolicy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScorePolicy.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.ranking;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RankingScorePolicy {
+    
+    private static final double VIEW_WEIGHT = 0.1;
+    private static final double LIKE_WEIGHT = 0.3;
+    private static final double ORDER_WEIGHT = 0.6;
+    
+    private static final double VIEW_SCORE = 1.0;
+    private static final double LIKE_SCORE = 1.0;
+    
+    public double calculateViewScore() {
+        return VIEW_SCORE * VIEW_WEIGHT;
+    }
+    
+    public double calculateLikeScore(int delta) {
+        return LIKE_SCORE * LIKE_WEIGHT * delta;
+    }
+    
+    public double calculateOrderScore(int quantity, Long amount) {
+        double baseScore = quantity * ORDER_WEIGHT;
+        
+        if (amount != null && amount > 0) {
+            double amountBonus = 1 + Math.log10(amount.doubleValue() / 10000);
+            return baseScore * Math.max(amountBonus, 1.0);
+        }
+        
+        return baseScore;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScorePolicy.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScorePolicy.java
@@ -10,7 +10,8 @@ public class RankingScorePolicy {
     private static final double ORDER_WEIGHT = 0.6;
     
     private static final double VIEW_SCORE = 1.0;
-    private static final double LIKE_SCORE = 1.0;
+    private static final double LIKE_SCORE = 3.0;
+    private static final double ORDER_SCORE = 7.0;
     
     public double calculateViewScore() {
         return VIEW_SCORE * VIEW_WEIGHT;
@@ -21,7 +22,7 @@ public class RankingScorePolicy {
     }
     
     public double calculateOrderScore(int quantity, Long amount) {
-        double baseScore = quantity * ORDER_WEIGHT;
+        double baseScore = ORDER_SCORE * quantity * ORDER_WEIGHT;
         
         if (amount != null && amount > 0) {
             double amountBonus = 1 + Math.log10(amount.doubleValue() / 10000);

--- a/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,49 @@
+package com.loopers.domain.ranking;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+public class RankingService {
+    
+    private static final String KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final long TTL_DAYS = 2;
+    
+    @Qualifier("masterRedisTemplate")
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RankingService(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void incrementScore(Long productId, double score, LocalDate date) {
+        String key = generateKey(date);
+        String member = generateMember(productId);
+        
+        ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+        Double newScore = zSetOps.incrementScore(key, member, score);
+        
+        redisTemplate.expire(key, TTL_DAYS, TimeUnit.DAYS);
+        
+        log.debug("랭킹 점수 업데이트 - key: {}, productId: {}, delta: {}, newScore: {}", 
+                key, productId, score, newScore);
+    }
+
+    private String generateKey(LocalDate date) {
+        return KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+    
+    private String generateMember(Long productId) {
+        return "product:" + productId;
+    }
+}

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/RankingConsumer.java
@@ -54,23 +54,51 @@ public class RankingConsumer {
         
         Map<Long, Double> scoreDeltas = new HashMap<>();
         LocalDate today = LocalDate.now();
+        int successCount = 0;
+        int failureCount = 0;
         
-        try {
-            for (ConsumerRecord<String, String> record : records) {
+        // 개별 메시지 처리 - 실패해도 계속 진행
+        for (ConsumerRecord<String, String> record : records) {
+            try {
                 processRecord(record, scoreDeltas);
+                successCount++;
+            } catch (Exception e) {
+                failureCount++;
+                log.error("개별 메시지 처리 실패, 스킵 - topic: {}, partition: {}, offset: {}, error: {}",
+                        record.topic(), record.partition(), record.offset(), e.getMessage());
+                // 상세 에러는 debug 레벨로
+                log.debug("메시지 처리 실패 상세", e);
             }
-            
-            scoreDeltas.forEach((productId, delta) -> {
-                rankingService.incrementScore(productId, delta, today);
-            });
-            
-            ack.acknowledge();
-            log.info("Ranking 컨슈머 - {} 개의 메시지 처리 완료, {} 개의 상품 점수 업데이트", 
-                    records.size(), scoreDeltas.size());
-            
-        } catch (Exception e) {
-            log.error("Ranking 처리 중 오류 발생", e);
-            throw e;
+        }
+        
+        // 성공적으로 처리된 점수만 Redis에 반영
+        if (!scoreDeltas.isEmpty()) {
+            try {
+                scoreDeltas.forEach((productId, delta) -> {
+                    rankingService.incrementScore(productId, delta, today);
+                });
+                log.info("Redis 점수 업데이트 완료 - {} 개 상품", scoreDeltas.size());
+            } catch (Exception e) {
+                log.error("Redis 업데이트 실패 - 점수 업데이트를 재시도해야 합니다", e);
+                // Redis 실패는 전체 배치에 영향을 주므로 예외를 던짐
+                throw new RuntimeException("Redis 점수 업데이트 실패", e);
+            }
+        }
+        
+        // 처리 완료 후 커밋
+        ack.acknowledge();
+        
+        // 처리 결과 로깅
+        log.info("Ranking 컨슈머 처리 완료 - 전체: {}, 성공: {}, 실패: {}, 점수 업데이트: {} 개 상품",
+                records.size(), successCount, failureCount, scoreDeltas.size());
+        
+        // 실패율이 높으면 경고
+        if (failureCount > 0) {
+            double failureRate = (double) failureCount / records.size() * 100;
+            if (failureRate > 10) {
+                log.warn("높은 실패율 감지 - 실패율: {:.2f}% ({}/{})", 
+                        failureRate, failureCount, records.size());
+            }
         }
     }
     
@@ -79,53 +107,84 @@ public class RankingConsumer {
         try {
             event = objectMapper.readValue(record.value(), BaseKafkaEvent.class);
         } catch (Exception e) {
-            log.error("JSON 파싱 오류 - topic: {}, partition: {}, offset: {}, value: {}", 
-                    record.topic(), record.partition(), record.offset(), record.value(), e);
-            throw new RuntimeException("이벤트 파싱 실패", e);
+            // JSON 파싱 실패는 복구 불가능하므로 예외를 던짐
+            throw new IllegalArgumentException(
+                    String.format("JSON 파싱 실패 - topic: %s, offset: %d", 
+                            record.topic(), record.offset()), e);
         }
         
         String eventId = event.getEventId();
         
+        // 멱등성 체크
         if (!idempotencyService.tryMarkAsProcessed(eventId, CONSUMER_GROUP)) {
             log.debug("이미 처리된 이벤트 스킵 - eventId: {}", eventId);
             return;
         }
         
-        try {
-            switch (event) {
-                case ProductViewedKafkaEvent viewEvent -> 
-                    accumulateScore(scoreDeltas, viewEvent.getProductId(), rankingScorePolicy.calculateViewScore());
-                case LikeChangedKafkaEvent likeEvent ->
-                    accumulateScore(scoreDeltas, likeEvent.getProductId(), 
-                            rankingScorePolicy.calculateLikeScore(likeEvent.getDeltaCount()));
-                case OrderCompletedKafkaEvent orderEvent ->
-                    processOrderEvent(orderEvent, scoreDeltas);
-                case StockAdjustedKafkaEvent stockEvent ->
-                    log.debug("재고 조정 이벤트는 랭킹에 반영하지 않음 - productId: {}", stockEvent.getProductId());
-                default ->
-                    log.debug("처리하지 않는 이벤트 타입 - type: {}", event.getEventType());
+        // 이벤트 타입별 처리
+        switch (event) {
+            case ProductViewedKafkaEvent viewEvent -> {
+                validateAndAccumulate(scoreDeltas, viewEvent.getProductId(), 
+                        rankingScorePolicy.calculateViewScore(), "VIEW");
             }
-        } catch (Exception e) {
-            log.error("랭킹 점수 계산 실패 - eventId: {}, type: {}", 
-                    eventId, event.getEventType(), e);
-            throw new RuntimeException("랭킹 점수 계산 실패", e);
+            case LikeChangedKafkaEvent likeEvent -> {
+                validateAndAccumulate(scoreDeltas, likeEvent.getProductId(),
+                        rankingScorePolicy.calculateLikeScore(likeEvent.getDeltaCount()), "LIKE");
+            }
+            case OrderCompletedKafkaEvent orderEvent -> {
+                processOrderEvent(orderEvent, scoreDeltas);
+            }
+            case StockAdjustedKafkaEvent stockEvent -> {
+                log.debug("재고 조정 이벤트는 랭킹에 반영하지 않음 - productId: {}", stockEvent.getProductId());
+            }
+            default -> {
+                log.debug("처리하지 않는 이벤트 타입 - type: {}", event.getEventType());
+            }
         }
+    }
+    
+    private void validateAndAccumulate(Map<Long, Double> scoreDeltas, Long productId, 
+                                      double score, String eventType) {
+        if (productId == null) {
+            throw new IllegalArgumentException(eventType + " 이벤트의 productId가 null입니다");
+        }
+        if (Double.isNaN(score) || Double.isInfinite(score)) {
+            throw new IllegalArgumentException(
+                    String.format("%s 이벤트의 점수가 유효하지 않습니다: %f", eventType, score));
+        }
+        accumulateScore(scoreDeltas, productId, score);
     }
     
     private void processOrderEvent(
             OrderCompletedKafkaEvent event,
             Map<Long, Double> scoreDeltas
     ) {
+        if (event.getItems() == null || event.getItems().isEmpty()) {
+            log.warn("주문 이벤트에 상품 정보가 없습니다 - orderId: {}", event.getAggregateId());
+            return;
+        }
+        
         event.getItems().forEach(item -> {
-            Long productId = item.getProductId();
-            int quantity = item.getQuantity();
-            Long amount = item.getPrice() * quantity;
-            
-            double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
-            accumulateScore(scoreDeltas, productId, score);
-            
-            log.debug("주문 점수 계산 - productId: {}, quantity: {}, amount: {}, score: {}", 
-                    productId, quantity, amount, score);
+            try {
+                Long productId = item.getProductId();
+                if (productId == null) {
+                    log.warn("주문 항목의 productId가 null입니다 - orderId: {}", event.getAggregateId());
+                    return;
+                }
+                
+                int quantity = item.getQuantity();
+                Long amount = item.getPrice() != null ? item.getPrice() * quantity : null;
+                
+                double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
+                validateAndAccumulate(scoreDeltas, productId, score, "ORDER");
+                
+                log.debug("주문 점수 계산 - productId: {}, quantity: {}, amount: {}, score: {}", 
+                        productId, quantity, amount, score);
+            } catch (Exception e) {
+                log.error("주문 항목 처리 실패 - orderId: {}, productId: {}", 
+                        event.getAggregateId(), item.getProductId(), e);
+                // 개별 주문 항목 실패는 전체를 실패시키지 않음
+            }
         });
     }
     

--- a/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/RankingConsumer.java
+++ b/apps/commerce-streamer/src/main/java/com/loopers/interfaces/consumer/RankingConsumer.java
@@ -1,0 +1,139 @@
+package com.loopers.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.event.IdempotencyService;
+import com.loopers.domain.ranking.RankingScorePolicy;
+import com.loopers.domain.ranking.RankingService;
+import com.loopers.infrastructure.kafka.event.*;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class RankingConsumer {
+    
+    private static final String CONSUMER_GROUP = "ranking-consumer";
+    
+    private final RankingService rankingService;
+    private final RankingScorePolicy rankingScorePolicy;
+    private final IdempotencyService idempotencyService;
+    private final ObjectMapper objectMapper;
+    
+    public RankingConsumer(
+            RankingService rankingService,
+            RankingScorePolicy rankingScorePolicy,
+            IdempotencyService idempotencyService,
+            ObjectMapper objectMapper
+    ) {
+        this.rankingService = rankingService;
+        this.rankingScorePolicy = rankingScorePolicy;
+        this.idempotencyService = idempotencyService;
+        this.objectMapper = objectMapper;
+    }
+    
+    @KafkaListener(
+        topics = {"catalog-events", "order-events"},
+        groupId = CONSUMER_GROUP,
+        containerFactory = "BATCH_LISTENER_DEFAULT"
+    )
+    @Transactional
+    public void consume(
+            List<ConsumerRecord<String, String>> records,
+            Acknowledgment ack
+    ) {
+        log.info("Ranking 컨슈머 - {} 개의 메시지 수신", records.size());
+        
+        Map<Long, Double> scoreDeltas = new HashMap<>();
+        LocalDate today = LocalDate.now();
+        
+        try {
+            for (ConsumerRecord<String, String> record : records) {
+                processRecord(record, scoreDeltas);
+            }
+            
+            scoreDeltas.forEach((productId, delta) -> {
+                rankingService.incrementScore(productId, delta, today);
+            });
+            
+            ack.acknowledge();
+            log.info("Ranking 컨슈머 - {} 개의 메시지 처리 완료, {} 개의 상품 점수 업데이트", 
+                    records.size(), scoreDeltas.size());
+            
+        } catch (Exception e) {
+            log.error("Ranking 처리 중 오류 발생", e);
+            throw e;
+        }
+    }
+    
+    private void processRecord(ConsumerRecord<String, String> record, Map<Long, Double> scoreDeltas) {
+        BaseKafkaEvent event;
+        try {
+            event = objectMapper.readValue(record.value(), BaseKafkaEvent.class);
+        } catch (Exception e) {
+            log.error("JSON 파싱 오류 - topic: {}, partition: {}, offset: {}, value: {}", 
+                    record.topic(), record.partition(), record.offset(), record.value(), e);
+            throw new RuntimeException("이벤트 파싱 실패", e);
+        }
+        
+        String eventId = event.getEventId();
+        
+        if (!idempotencyService.tryMarkAsProcessed(eventId, CONSUMER_GROUP)) {
+            log.debug("이미 처리된 이벤트 스킵 - eventId: {}", eventId);
+            return;
+        }
+        
+        try {
+            switch (event) {
+                case ProductViewedKafkaEvent viewEvent -> 
+                    accumulateScore(scoreDeltas, viewEvent.getProductId(), rankingScorePolicy.calculateViewScore());
+                case LikeChangedKafkaEvent likeEvent ->
+                    accumulateScore(scoreDeltas, likeEvent.getProductId(), 
+                            rankingScorePolicy.calculateLikeScore(likeEvent.getDeltaCount()));
+                case OrderCompletedKafkaEvent orderEvent ->
+                    processOrderEvent(orderEvent, scoreDeltas);
+                case StockAdjustedKafkaEvent stockEvent ->
+                    log.debug("재고 조정 이벤트는 랭킹에 반영하지 않음 - productId: {}", stockEvent.getProductId());
+                default ->
+                    log.debug("처리하지 않는 이벤트 타입 - type: {}", event.getEventType());
+            }
+        } catch (Exception e) {
+            log.error("랭킹 점수 계산 실패 - eventId: {}, type: {}", 
+                    eventId, event.getEventType(), e);
+            throw new RuntimeException("랭킹 점수 계산 실패", e);
+        }
+    }
+    
+    private void processOrderEvent(
+            OrderCompletedKafkaEvent event,
+            Map<Long, Double> scoreDeltas
+    ) {
+        event.getItems().forEach(item -> {
+            Long productId = item.getProductId();
+            int quantity = item.getQuantity();
+            Long amount = item.getPrice() * quantity;
+            
+            double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
+            accumulateScore(scoreDeltas, productId, score);
+            
+            log.debug("주문 점수 계산 - productId: {}, quantity: {}, amount: {}, score: {}", 
+                    productId, quantity, amount, score);
+        });
+    }
+    
+    private void accumulateScore(
+            Map<Long, Double> scoreDeltas,
+            Long productId,
+            double score
+    ) {
+        scoreDeltas.merge(productId, score, Double::sum);
+    }
+}

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/ranking/RankingScorePolicyTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/ranking/RankingScorePolicyTest.java
@@ -31,7 +31,7 @@ class RankingScorePolicyTest {
     @Nested
     class CalculateLikeScore {
         
-        @DisplayName("좋아요가 증가하면 가중치 0.3이 적용된 양수 점수가 반환된다")
+        @DisplayName("좋아요가 증가하면 스코어 3.0과 가중치 0.3이 적용된 양수 점수가 반환된다")
         @Test
         void returnPositiveScore_whenLikeIncreases() {
             // arrange
@@ -41,10 +41,10 @@ class RankingScorePolicyTest {
             double score = rankingScorePolicy.calculateLikeScore(delta);
             
             // assert
-            assertThat(score).isEqualTo(0.6); // 2 * 0.3
+            assertThat(score).isCloseTo(1.8, within(0.0000001)); // 2 * 3.0 * 0.3
         }
         
-        @DisplayName("좋아요가 취소되면 가중치 0.3이 적용된 음수 점수가 반환된다")
+        @DisplayName("좋아요가 취소되면 스코어 3.0과 가중치 0.3이 적용된 음수 점수가 반환된다")
         @Test
         void returnNegativeScore_whenLikeCancelled() {
             // arrange
@@ -54,7 +54,7 @@ class RankingScorePolicyTest {
             double score = rankingScorePolicy.calculateLikeScore(delta);
             
             // assert
-            assertThat(score).isEqualTo(-0.3); // -1 * 0.3
+            assertThat(score).isCloseTo(-0.9, within(0.0000001)); // -1 * 3.0 * 0.3
         }
     }
     
@@ -73,9 +73,12 @@ class RankingScorePolicyTest {
             double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
             
             // assert
+            // 7.0 * 2 * 0.6 = 8.4 기본점수
+            // 로그 보너스: 1 + log10(50000/10000) = 1.699 
+            // 최종: 8.4 * 1.699 = 14.27
             assertAll(
-                () -> assertThat(score).isGreaterThan(2.0),
-                () -> assertThat(score).isLessThan(2.1)
+                () -> assertThat(score).isGreaterThan(14.2),
+                () -> assertThat(score).isLessThan(14.3)
             );
         }
         
@@ -90,7 +93,7 @@ class RankingScorePolicyTest {
             double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
             
             // assert
-            assertThat(score).isCloseTo(1.8, within(0.0000001)); // 0.6 * 3
+            assertThat(score).isCloseTo(12.6, within(0.0000001)); // 7.0 * 1 * 0.6 * 3 (로그 보너스)
         }
         
         @DisplayName("금액 정보가 없으면 수량에 대한 기본 가중치만 적용된다")
@@ -104,7 +107,7 @@ class RankingScorePolicyTest {
             double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
             
             // assert
-            assertThat(score).isCloseTo(1.8, within(0.0000001)); // 3 * 0.6
+            assertThat(score).isCloseTo(12.6, within(0.0000001)); // 7.0 * 3 * 0.6
         }
     }
 }

--- a/apps/commerce-streamer/src/test/java/com/loopers/domain/ranking/RankingScorePolicyTest.java
+++ b/apps/commerce-streamer/src/test/java/com/loopers/domain/ranking/RankingScorePolicyTest.java
@@ -1,0 +1,110 @@
+package com.loopers.domain.ranking;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class RankingScorePolicyTest {
+    
+    private final RankingScorePolicy rankingScorePolicy = new RankingScorePolicy();
+    
+    @DisplayName("조회 점수 계산 시")
+    @Nested
+    class CalculateViewScore {
+        
+        @DisplayName("조회 이벤트가 발생하면 가중치 0.1이 적용된 점수가 반환된다")
+        @Test
+        void returnWeightedScore_whenViewEventOccurs() {
+            // arrange & act
+            double score = rankingScorePolicy.calculateViewScore();
+            
+            // assert
+            assertThat(score).isEqualTo(0.1);
+        }
+    }
+    
+    @DisplayName("좋아요 점수 계산 시")
+    @Nested
+    class CalculateLikeScore {
+        
+        @DisplayName("좋아요가 증가하면 가중치 0.3이 적용된 양수 점수가 반환된다")
+        @Test
+        void returnPositiveScore_whenLikeIncreases() {
+            // arrange
+            int delta = 2;
+            
+            // act
+            double score = rankingScorePolicy.calculateLikeScore(delta);
+            
+            // assert
+            assertThat(score).isEqualTo(0.6); // 2 * 0.3
+        }
+        
+        @DisplayName("좋아요가 취소되면 가중치 0.3이 적용된 음수 점수가 반환된다")
+        @Test
+        void returnNegativeScore_whenLikeCancelled() {
+            // arrange
+            int delta = -1;
+            
+            // act
+            double score = rankingScorePolicy.calculateLikeScore(delta);
+            
+            // assert
+            assertThat(score).isEqualTo(-0.3); // -1 * 0.3
+        }
+    }
+    
+    @DisplayName("주문 점수 계산 시")
+    @Nested
+    class CalculateOrderScore {
+        
+        @DisplayName("일반 주문이 발생하면 수량과 금액에 따른 가중치가 적용된다")
+        @Test
+        void applyQuantityAndAmountWeight_whenOrderOccurs() {
+            // arrange
+            int quantity = 2;
+            Long amount = 50000L;
+            
+            // act
+            double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
+            
+            // assert
+            assertAll(
+                () -> assertThat(score).isGreaterThan(2.0),
+                () -> assertThat(score).isLessThan(2.1)
+            );
+        }
+        
+        @DisplayName("고액 주문이 발생하면 추가 보너스가 적용된다")
+        @Test
+        void applyBonusScore_whenHighAmountOrder() {
+            // arrange
+            int quantity = 1;
+            Long amount = 1000000L; // 100만원
+            
+            // act
+            double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
+            
+            // assert
+            assertThat(score).isCloseTo(1.8, within(0.0000001)); // 0.6 * 3
+        }
+        
+        @DisplayName("금액 정보가 없으면 수량에 대한 기본 가중치만 적용된다")
+        @Test
+        void applyOnlyQuantityWeight_whenAmountIsNull() {
+            // arrange
+            int quantity = 3;
+            Long amount = null;
+            
+            // act
+            double score = rankingScorePolicy.calculateOrderScore(quantity, amount);
+            
+            // assert
+            assertThat(score).isCloseTo(1.8, within(0.0000001)); // 3 * 0.6
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary

+ Kafka Consumer -> Redis ZSET 적재 로직 구현
+ Ranking API 구현

## 💬 Review Points

### [Kafka 배치 처리 시 에러 격리 전략](https://github.com/beurre-noisette/loopers/pull/9/commits/d01032a8f062926a30c4e607e4bf5f1b9fe42f0a)

최대 3000개의 메시지를 배치로 처리하는데 하나의 메시지 오류로 전체가 실패하는 문제를 해결하기 위해, 개별 메시지 단위로 `try-catch`를 분리하여 에러를 격리하는 방식으로 구현했습니다.
구현 의도는 대량 트래픽 상황에서 일부 메시지의 오류가 전체 랭킹 업데이트를 지연시키는 것을 방지하고 시스템의 가용성을 높이기 위함인데요. 이러한 구현에 대한 멘토님의 의견을 여쭙고 싶습니다.

### [이벤트별 차별화된 스코어 및 가중치 적용](https://github.com/beurre-noisette/loopers/blob/feat/round-9/apps/commerce-streamer/src/main/java/com/loopers/domain/ranking/RankingScorePolicy.java#L5-L34)

조회, 좋아요, 주문 이벤트가 랭킹에 다른 영향력을 갖도록 하기 위해, 스코어(VIEW = 1, LIKE = 3, ORDER = 7)와 가중치(0.1, 0.3, 0.6)를 분리한 2단계 점수 계산 체계로 구현했습니다. 구현 의도는 각 이벤트의 절대적 중요도(스코어)와 전체 랭킹에서의 비중(가중치)을 독립적으로 조절할 수 있게 하여, 비즈니스 정책 변경 시 유연하게 대응해볼 수 있지 않을까하여 현재 상태처럼 구현하였습니다.
이러한 구현에 대한 멘토님의 의견을 여쭙고 싶습니다.

### [랭킹 조회 시 Redis 순서 보장](https://github.com/beurre-noisette/loopers/blob/feat/round-9/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingQuery.java#L30-L102)

랭킹 API에서 상품 ID뿐만 아니라 상품 상세 정보도 함께 제공해야 하는 요구사항을 해결하기 위해, Redis에서 정렬된 상품 ID를 먼저 조회하고, DB에서 `findProductsByIds`로 상품 정보를 일괄 조회한 뒤, Redis 순서를 유지하며 데이터를 조합하는 방식으로 구현했습니다. 구현을 이렇게 한 의도는 N+1 쿼리 문제를 방지하면서도 Redis ZSET의 정렬 순서를 정확히 유지하여 올바른 랭킹을 보장하기 위함입니다. 이러한 구현에 대한 멘토님의 의견을 여쭙고 싶습니다.

## ✅ Checklist

### 📈 Ranking Consumer

✅  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
✅  날짜별로 적재할 키를 계산하는 기능을 만들었다
✅  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

✅  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
✅  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
✅  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)